### PR TITLE
Tile viewer

### DIFF
--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using xTile;
 using StardewValley;
+using StardewValley.Menus;
+using stardew_access.Features;
 
 
 namespace stardew_access.Features
@@ -11,15 +13,18 @@ namespace stardew_access.Features
     {
 
         private Vector2 ViewingOffset = Vector2.Zero;
+        private Vector2 relativeOffsetLockPosition = Vector2.Zero;
+        private Boolean relativeOffsetLock = false;
+        private Vector2 prevPlayerPosition = Vector2.Zero, prevFacing = Vector2.Zero;
 
         private Vector2 PlayerFacingVector
         {
             get
             {
-switch (Game1.player.FacingDirection)
+                switch (Game1.player.FacingDirection)
                 {
                     case 0:
-                        return new Vector2(0, - Game1.tileSize);
+                        return new Vector2(0, -Game1.tileSize);
                     case 1:
                         return new Vector2(Game1.tileSize, 0);
                     case 2:
@@ -36,24 +41,55 @@ switch (Game1.player.FacingDirection)
         {
             get
             {
-                int x = Game1.player.GetBoundingBox().Center.X - Game1.viewport.X;
-                int y = Game1.player.GetBoundingBox().Center.Y - Game1.viewport.Y;
+                int x = Game1.player.GetBoundingBox().Center.X;
+                int y = Game1.player.GetBoundingBox().Center.Y;
                 return new Vector2(x, y);
             }
         }
 
-        private static (int, int) GetMapTileDimensions()
+        private Vector2 getTileCursorPosition()
         {
-            Map map = Game1.currentLocation.map;
-            return (map.Layers[0].LayerWidth, map.Layers[0].LayerHeight);
+            Vector2 target = this.PlayerPosition;
+            if (this.relativeOffsetLock)
+            {
+                target += this.relativeOffsetLockPosition;
+            }
+            else
+            {
+                target += this.PlayerFacingVector + this.ViewingOffset;
+            }
+            return target;
         }
-            
-        public bool MoveTileView(Vector2 delta)
+
+        private void cursorMoveInput(Vector2 delta, Boolean precise = false)
         {
-            Vector2 dest = this.PlayerPosition + this.PlayerFacingVector + this.ViewingOffset + delta;
+            if (!tryMoveTileView(delta)) return;
+            Vector2 position = this.getTileCursorPosition();
+            String ?name = TileInfo.getNameAtTile(position / Game1.tileSize);
+            if (name == null)
+            {
+                name = "empty tile";
+            }
+            if (precise)
+            {
+                MainClass.ScreenReader.Say($"{position.X}, {position.Y}", true);
+            }
+            else
+            {
+                MainClass.ScreenReader.Say($"{name}, {(int)(position.X / Game1.tileSize)}, {(int)(position.Y / Game1.tileSize)}", true);
+            }
+        }
+
+        private bool tryMoveTileView(Vector2 delta)
+        {
+            Vector2 dest = this.getTileCursorPosition() + delta;
             if (Utility.isOnScreen(dest, 0))
             {
-                this.ViewingOffset += delta;
+                if (this.relativeOffsetLock)
+                    this.relativeOffsetLockPosition += delta;
+                else
+                    this.ViewingOffset += delta;
+
                 return true;
             }
             return false;
@@ -61,24 +97,54 @@ switch (Game1.player.FacingDirection)
 
         private void SnapMouseToPlayer()
         {
-            Vector2 snapPosition = this.PlayerPosition + this.PlayerFacingVector + this.ViewingOffset;
-            Point snapPoint = new Point((int)snapPosition.X, (int)snapPosition.Y);
-            if (Utility.isOnScreen(snapPoint, 0))
-            Game1.setMousePosition(snapPoint.X, snapPoint.Y);
+            Vector2 cursorPosition = this.getTileCursorPosition();
+                        if (allowMouseSnap(cursorPosition))
+                Game1.setMousePosition((int)cursorPosition.X - Game1.viewport.X, (int)cursorPosition.Y - Game1.viewport.Y);
         }
 
-public void update()
+        public void update()
         {
+            if (this.prevFacing != this.PlayerFacingVector || this.prevPlayerPosition != this.PlayerPosition)
+            {
+                this.ViewingOffset = Vector2.Zero;
+            }
+            this.prevFacing = this.PlayerFacingVector;
+            this.prevPlayerPosition = this.PlayerPosition;
             if (MainClass.Config.SnapMouse)
-            this.SnapMouseToPlayer();
+                this.SnapMouseToPlayer();
+            if (MainClass.Config.TileCursorUpKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(0, -Game1.tileSize));
+            }
+            else if (MainClass.Config.TileCursorRightKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(Game1.tileSize, 0));
+            }
+            else if (MainClass.Config.TileCursorDownKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(0, Game1.tileSize));
+            }
+            else if (MainClass.Config.TileCursorLeftKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(-Game1.tileSize, 0));
+            }
         }
-    
-    private static bool IsTileOnMap(Vector2 tile)
-    {
-        (int width, int height) dimensions = GetMapTileDimensions();
-        if (tile.X < 0 || tile.X >= dimensions.width) return false;
-        if (tile.Y < 0 || tile.Y >= dimensions.height) return false;
-        return true;
+
+
+        private static bool allowMouseSnap(Vector2 point)
+        {
+            if (!Utility.isOnScreen(point, 0)) return false;
+
+            //prevent mousing over the toolbar or any other UI component with the tile cursor
+            foreach (IClickableMenu menu in Game1.onScreenMenus)
+            {
+                if (menu.allClickableComponents == null) continue;
+                foreach (ClickableComponent component in menu.allClickableComponents)
+                {
+                    if (component.containsPoint((int)point.X, (int)point.Y)) return false;
+                }
+            }
+            return true;
+        }
     }
-}
 }

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -63,7 +63,23 @@ namespace stardew_access.Features
 
         public void HandleInput()
         {
-            if (MainClass.Config.TileCursorUpKey.JustPressed())
+            if (MainClass.Config.TileCursorPreciseUpKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(0, -MainClass.Config.TileCursorPreciseMovementDistance), true);
+            }
+            else if (MainClass.Config.TileCursorPreciseRightKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(MainClass.Config.TileCursorPreciseMovementDistance, 0), true);
+            }
+            else if (MainClass.Config.TileCursorPreciseDownKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(0, MainClass.Config.TileCursorPreciseMovementDistance), true);
+            }
+            else if (MainClass.Config.TileCursorPreciseLeftKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(-MainClass.Config.TileCursorPreciseMovementDistance, 0), true);
+            }
+            else if (MainClass.Config.TileCursorUpKey.JustPressed())
             {
                 this.cursorMoveInput(new Vector2(0, -Game1.tileSize));
             }

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -61,6 +61,26 @@ namespace stardew_access.Features
             return target;
         }
 
+        public void HandleInput()
+        {
+            if (MainClass.Config.TileCursorUpKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(0, -Game1.tileSize));
+            }
+            else if (MainClass.Config.TileCursorRightKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(Game1.tileSize, 0));
+            }
+            else if (MainClass.Config.TileCursorDownKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(0, Game1.tileSize));
+            }
+            else if (MainClass.Config.TileCursorLeftKey.JustPressed())
+            {
+                this.cursorMoveInput(new Vector2(-Game1.tileSize, 0));
+            }
+        }
+
         private void cursorMoveInput(Vector2 delta, Boolean precise = false)
         {
                         if (!tryMoveTileView(delta)) return;
@@ -120,23 +140,6 @@ namespace stardew_access.Features
             this.prevPlayerPosition = this.PlayerPosition;
             if (MainClass.Config.SnapMouse)
                 this.SnapMouseToPlayer();
-
-            if (MainClass.Config.TileCursorUpKey.JustPressed())
-            {
-                this.cursorMoveInput(new Vector2(0, -Game1.tileSize));
-            }
-            else if (MainClass.Config.TileCursorRightKey.JustPressed())
-            {
-                this.cursorMoveInput(new Vector2(Game1.tileSize, 0));
-            }
-            else if (MainClass.Config.TileCursorDownKey.JustPressed())
-            {
-                this.cursorMoveInput(new Vector2(0, Game1.tileSize));
-            }
-            else if (MainClass.Config.TileCursorLeftKey.JustPressed())
-            {
-                this.cursorMoveInput(new Vector2(-Game1.tileSize, 0));
-            }
         }
 
         private static bool allowMouseSnap(Vector2 point)
@@ -146,11 +149,7 @@ namespace stardew_access.Features
             //prevent mousing over the toolbar or any other UI component with the tile cursor
             foreach (IClickableMenu menu in Game1.onScreenMenus)
             {
-                if (menu.allClickableComponents == null) continue;
-                foreach (ClickableComponent component in menu.allClickableComponents)
-                {
-                    if (component.containsPoint((int)point.X, (int)point.Y)) return false;
-                }
+                if (menu.isWithinBounds((int)point.X - Game1.viewport.X, (int)point.Y - Game1.viewport.Y)) return false;
             }
             return true;
         }

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using StardewValley;
+
+namespace stardew_access.Features
+{
+    public class MouseHandler
+    {
+
+        public Vector2 ViewingOffset { get; set; } = Vector2.Zero;
+
+        public Vector2 PlayerFacingVector
+        {
+            get
+            {
+switch (Game1.player.FacingDirection)
+                {
+                    case 0:
+                        return new Vector2(0, - Game1.tileSize);
+                    case 1:
+                        return new Vector2(Game1.tileSize, 0);
+                    case 2:
+                        return new Vector2(0, Game1.tileSize);
+                    case 3:
+                        return new Vector2(-Game1.tileSize, 0);
+                    default:
+                        return Vector2.Zero;
+                }
+            }
+        }
+
+        public Vector2 PlayerPosition
+        {
+            get
+            {
+                int x = Game1.player.GetBoundingBox().Center.X - Game1.viewport.X;
+                int y = Game1.player.GetBoundingBox().Center.Y - Game1.viewport.Y;
+                return new Vector2(x, y);
+            }
+        }
+
+        public void SnapMouseToPlayer()
+        {
+            Vector2 snapPosition = this.PlayerPosition + this.PlayerFacingVector + this.ViewingOffset;
+            if (Utility.isOnScreen(snapPosition, 0))
+            Game1.setMousePosition((int)snapPosition.X, (int)snapPosition.Y);
+        }
+    }
+}

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
+using xTile;
 using StardewValley;
+
 
 namespace stardew_access.Features
 {
@@ -40,6 +42,23 @@ switch (Game1.player.FacingDirection)
             }
         }
 
+        private static (int, int) GetMapTileDimensions()
+        {
+            Map map = Game1.currentLocation.map;
+            return (map.Layers[0].LayerWidth, map.Layers[0].LayerHeight);
+        }
+            
+        public bool MoveTileView(Vector2 delta)
+        {
+            Vector2 dest = this.PlayerPosition + this.PlayerFacingVector + this.ViewingOffset + delta;
+            if (Utility.isOnScreen(dest, 0))
+            {
+                this.ViewingOffset += delta;
+                return true;
+            }
+            return false;
+        }
+
         private void SnapMouseToPlayer()
         {
             Vector2 snapPosition = this.PlayerPosition + this.PlayerFacingVector + this.ViewingOffset;
@@ -53,5 +72,13 @@ public void update()
             if (MainClass.Config.SnapMouse)
             this.SnapMouseToPlayer();
         }
+    
+    private static bool IsTileOnMap(Vector2 tile)
+    {
+        (int width, int height) dimensions = GetMapTileDimensions();
+        if (tile.X < 0 || tile.X >= dimensions.width) return false;
+        if (tile.Y < 0 || tile.Y >= dimensions.height) return false;
+        return true;
     }
+}
 }

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -8,9 +8,9 @@ namespace stardew_access.Features
     public class MouseHandler
     {
 
-        public Vector2 ViewingOffset { get; set; } = Vector2.Zero;
+        private Vector2 ViewingOffset = Vector2.Zero;
 
-        public Vector2 PlayerFacingVector
+        private Vector2 PlayerFacingVector
         {
             get
             {
@@ -30,7 +30,7 @@ switch (Game1.player.FacingDirection)
             }
         }
 
-        public Vector2 PlayerPosition
+        private Vector2 PlayerPosition
         {
             get
             {
@@ -40,11 +40,18 @@ switch (Game1.player.FacingDirection)
             }
         }
 
-        public void SnapMouseToPlayer()
+        private void SnapMouseToPlayer()
         {
             Vector2 snapPosition = this.PlayerPosition + this.PlayerFacingVector + this.ViewingOffset;
-            if (Utility.isOnScreen(snapPosition, 0))
-            Game1.setMousePosition((int)snapPosition.X, (int)snapPosition.Y);
+            Point snapPoint = new Point((int)snapPosition.X, (int)snapPosition.Y);
+            if (Utility.isOnScreen(snapPoint, 0))
+            Game1.setMousePosition(snapPoint.X, snapPoint.Y);
+        }
+
+public void update()
+        {
+            if (MainClass.Config.SnapMouse)
+            this.SnapMouseToPlayer();
         }
     }
 }

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -63,7 +63,18 @@ namespace stardew_access.Features
 
         public void HandleInput()
         {
-            if (MainClass.Config.TileCursorPreciseUpKey.JustPressed())
+            if (MainClass.Config.ToggleRelativeCursorLockKey.JustPressed())
+            {
+                this.relativeOffsetLock = !this.relativeOffsetLock;
+                if (this.relativeOffsetLock)
+                {
+                    this.relativeOffsetLockPosition = this.PlayerFacingVector + this.ViewingOffset;
+                } else { 
+                    this.relativeOffsetLockPosition = Vector2.Zero;
+                }
+                MainClass.ScreenReader.Say("Relative cursor lock " + (this.relativeOffsetLock ? "enabled" : "disabled") + ".", true);
+            }
+                    else if (MainClass.Config.TileCursorPreciseUpKey.JustPressed())
             {
                 this.cursorMoveInput(new Vector2(0, -MainClass.Config.TileCursorPreciseMovementDistance), true);
             }

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -63,9 +63,9 @@ namespace stardew_access.Features
 
         private void cursorMoveInput(Vector2 delta, Boolean precise = false)
         {
-            if (!tryMoveTileView(delta)) return;
+                        if (!tryMoveTileView(delta)) return;
             Vector2 position = this.getTileCursorPosition();
-            Vector2 tile = position / Game1.tileSize;
+            Vector2 tile = new Vector2((float)Math.Floor(position.X / Game1.tileSize), (float)Math.Floor(position.Y / Game1.tileSize));
             String ?name = TileInfo.getNameAtTile(tile);
             if (name == null)
             {
@@ -79,7 +79,7 @@ namespace stardew_access.Features
             }
             if (precise)
             {
-                MainClass.ScreenReader.Say($"{position.X}, {position.Y}", true);
+                MainClass.ScreenReader.Say($"{name}, {position.X}, {position.Y}", true);
             }
             else
             {
@@ -111,6 +111,7 @@ namespace stardew_access.Features
 
         public void update()
         {
+            //Reset the viewing cursor to the player when they turn or move. This will not reset the locked offset relative cursor position.
             if (this.prevFacing != this.PlayerFacingVector || this.prevPlayerPosition != this.PlayerPosition)
             {
                 this.ViewingOffset = Vector2.Zero;
@@ -119,6 +120,7 @@ namespace stardew_access.Features
             this.prevPlayerPosition = this.PlayerPosition;
             if (MainClass.Config.SnapMouse)
                 this.SnapMouseToPlayer();
+
             if (MainClass.Config.TileCursorUpKey.JustPressed())
             {
                 this.cursorMoveInput(new Vector2(0, -Game1.tileSize));
@@ -136,7 +138,6 @@ namespace stardew_access.Features
                 this.cursorMoveInput(new Vector2(-Game1.tileSize, 0));
             }
         }
-
 
         private static bool allowMouseSnap(Vector2 point)
         {

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -65,10 +65,17 @@ namespace stardew_access.Features
         {
             if (!tryMoveTileView(delta)) return;
             Vector2 position = this.getTileCursorPosition();
-            String ?name = TileInfo.getNameAtTile(position / Game1.tileSize);
+            Vector2 tile = position / Game1.tileSize;
+            String ?name = TileInfo.getNameAtTile(tile);
             if (name == null)
             {
-                name = "empty tile";
+                if (TileInfo.isCollidingAtTile((int)tile.X, (int)tile.Y))
+                {
+                    name = "blocked";
+                } else
+                {
+                    name = "empty";
+                }
             }
             if (precise)
             {

--- a/stardew-access/Features/MouseHandler.cs
+++ b/stardew-access/Features/MouseHandler.cs
@@ -6,7 +6,6 @@ using StardewValley;
 using StardewValley.Menus;
 using stardew_access.Features;
 
-
 namespace stardew_access.Features
 {
     public class MouseHandler
@@ -137,13 +136,13 @@ namespace stardew_access.Features
         private bool tryMoveTileView(Vector2 delta)
         {
             Vector2 dest = this.getTileCursorPosition() + delta;
-            if (Utility.isOnScreen(dest, 0))
+            if (!isPositionOnMap(dest)) return false;
+            if ((MainClass.Config.LimitTileCursorToScreen && Utility.isOnScreen(dest, 0)) || !MainClass.Config.LimitTileCursorToScreen)
             {
                 if (this.relativeOffsetLock)
                     this.relativeOffsetLockPosition += delta;
                 else
                     this.ViewingOffset += delta;
-
                 return true;
             }
             return false;
@@ -178,6 +177,14 @@ namespace stardew_access.Features
             {
                 if (menu.isWithinBounds((int)point.X - Game1.viewport.X, (int)point.Y - Game1.viewport.Y)) return false;
             }
+            return true;
+        }
+
+        private static bool isPositionOnMap(Vector2 position)
+        {
+            Map map = Game1.currentLocation.map;
+            if (position.X < 0 || position.X > map.Layers[0].DisplayWidth) return false;
+            if (position.Y < 0 || position.Y > map.Layers[0].DisplayHeight) return false;
             return true;
         }
     }

--- a/stardew-access/Features/Other.cs
+++ b/stardew-access/Features/Other.cs
@@ -41,32 +41,6 @@ namespace stardew_access.Features
             MainClass.ScreenReader.Say($"{currentLocation.Name} Entered", true);
         }
 
-        public static void SnapMouseToPlayer()
-        {
-            int x = Game1.player.GetBoundingBox().Center.X - Game1.viewport.X;
-            int y = Game1.player.GetBoundingBox().Center.Y - Game1.viewport.Y;
-
-            int offset = 64;
-
-            switch (Game1.player.FacingDirection)
-            {
-                case 0:
-                    y -= offset;
-                    break;
-                case 1:
-                    x += offset;
-                    break;
-                case 2:
-                    y += offset;
-                    break;
-                case 3:
-                    x -= offset;
-                    break;
-            }
-
-            Game1.setMousePosition(x, y);
-        }
-
         public static void narrateHudMessages()
         {
             try

--- a/stardew-access/Features/Radar.cs
+++ b/stardew-access/Features/Radar.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.Objects;
 

--- a/stardew-access/Features/TileViewer.cs
+++ b/stardew-access/Features/TileViewer.cs
@@ -8,7 +8,7 @@ using stardew_access.Features;
 
 namespace stardew_access.Features
 {
-    public class MouseHandler
+    public class TileViewer
     {
 
         private Vector2 ViewingOffset = Vector2.Zero;

--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -26,6 +26,16 @@ namespace stardew_access
         public KeybindList ReadTileKey { get; set; } = KeybindList.Parse("J");
         public KeybindList ReadStandingTileKey { get; set; } = KeybindList.Parse("LeftAlt + J");
 
+        //Tile viewer keys
+        public KeybindList TileCursorUpKey { get; set; } = KeybindList.Parse("Up");
+        public KeybindList TileCursorRightKey { get; set; } = KeybindList.Parse("Right");
+        public KeybindList TileCursorDownKey { get; set; } = KeybindList.Parse("Down");
+        public KeybindList TileCursorLeftKey { get; set; } = KeybindList.Parse("Left");
+        public KeybindList TileCursorPreciseUpKey { get; set; } = KeybindList.Parse("LeftShift + Up");
+        public KeybindList TileCursorPreciseRightKey { get; set; } = KeybindList.Parse("LeftShift + Right");
+        public KeybindList TileCursorPreciseDownKey { get; set; } = KeybindList.Parse("LeftShift + Down");
+        public KeybindList TileCursorPreciseLeftKey { get; set; } = KeybindList.Parse("LeftShift + Left");
+
         #endregion
 
         // TODO Add the exclusion and focus list too

--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -25,6 +25,7 @@ namespace stardew_access
         public KeybindList TimeNSeasonKey { get; set; } = KeybindList.Parse("Q");
         public KeybindList ReadTileKey { get; set; } = KeybindList.Parse("J");
         public KeybindList ReadStandingTileKey { get; set; } = KeybindList.Parse("LeftAlt + J");
+        public int TileCursorPreciseMovementDistance { get; set; } = 8;
 
         //Tile viewer keys
         public KeybindList TileCursorUpKey { get; set; } = KeybindList.Parse("Up");
@@ -35,7 +36,7 @@ namespace stardew_access
         public KeybindList TileCursorPreciseRightKey { get; set; } = KeybindList.Parse("LeftShift + Right");
         public KeybindList TileCursorPreciseDownKey { get; set; } = KeybindList.Parse("LeftShift + Down");
         public KeybindList TileCursorPreciseLeftKey { get; set; } = KeybindList.Parse("LeftShift + Left");
-
+        public KeybindList ToggleRelativeCursorLockKey { get; set; } = KeybindList.Parse("L");
         #endregion
 
         // TODO Add the exclusion and focus list too

--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -25,6 +25,7 @@ namespace stardew_access
         public KeybindList TimeNSeasonKey { get; set; } = KeybindList.Parse("Q");
         public KeybindList ReadTileKey { get; set; } = KeybindList.Parse("J");
         public KeybindList ReadStandingTileKey { get; set; } = KeybindList.Parse("LeftAlt + J");
+        public bool LimitTileCursorToScreen { get; set; } = false;
         public int TileCursorPreciseMovementDistance { get; set; } = 8;
 
         //Tile viewer keys

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -142,8 +142,7 @@ get
             // Narrate current location's name
             Other.narrateCurrentLocation();
 
-            if (Config.SnapMouse)
-                Mouse.SnapMouseToPlayer();
+            Mouse.update();
 
             if (!ReadTile.isReadingTile && Config.ReadTile)
             {

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -66,7 +66,7 @@ namespace stardew_access
 
         public static TileViewer TileViewer
         {
-get
+            get
             {
                 if (tileViewer == null)
                     tileViewer = new TileViewer();

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -267,6 +267,9 @@ get
                 ReadTile.run(manuallyTriggered: true);
                 return;
             }
+
+            // Tile viewing cursor keys
+            Mouse.HandleInput();
         }
 
         public static void ErrorLog(string message)

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -20,6 +20,7 @@ namespace stardew_access
         private static StaticTiles? sTiles;
         private static IScreenReader? screenReader;
         private static IModHelper? modHelper;
+        private static MouseHandler? mouse;
 
         internal static ModConfig Config { get => config; set => config = value; }
         public static IModHelper? ModHelper { get => modHelper; }
@@ -62,6 +63,17 @@ namespace stardew_access
 
             set => screenReader = value;
         }
+
+        public static MouseHandler Mouse
+        {
+get
+            {
+                if (mouse == null)
+                    mouse = new MouseHandler();
+                return mouse;
+            }
+        }
+
         #endregion
 
         /*********
@@ -131,7 +143,7 @@ namespace stardew_access
             Other.narrateCurrentLocation();
 
             if (Config.SnapMouse)
-                Other.SnapMouseToPlayer();
+                Mouse.SnapMouseToPlayer();
 
             if (!ReadTile.isReadingTile && Config.ReadTile)
             {

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -20,7 +20,7 @@ namespace stardew_access
         private static StaticTiles? sTiles;
         private static IScreenReader? screenReader;
         private static IModHelper? modHelper;
-        private static MouseHandler? mouse;
+        private static TileViewer? tileViewer;
 
         internal static ModConfig Config { get => config; set => config = value; }
         public static IModHelper? ModHelper { get => modHelper; }
@@ -64,13 +64,13 @@ namespace stardew_access
             set => screenReader = value;
         }
 
-        public static MouseHandler Mouse
+        public static TileViewer TileViewer
         {
 get
             {
-                if (mouse == null)
-                    mouse = new MouseHandler();
-                return mouse;
+                if (tileViewer == null)
+                    tileViewer = new TileViewer();
+                return tileViewer;
             }
         }
 
@@ -142,7 +142,8 @@ get
             // Narrate current location's name
             Other.narrateCurrentLocation();
 
-            Mouse.update();
+            //handle TileCursor update logic
+            TileViewer.update();
 
             if (!ReadTile.isReadingTile && Config.ReadTile)
             {
@@ -269,7 +270,7 @@ get
             }
 
             // Tile viewing cursor keys
-            Mouse.HandleInput();
+            TileViewer.HandleInput();
         }
 
         public static void ErrorLog(string message)


### PR DESCRIPTION
This adds the ability to browse the map with the arrow keys and snap the mouse cursor to specific tiles.

* You can use the arrow keys (by default) to browse by tile.
* You can use shift plus the arrow keys (by default) to browse by a set pixel amount (defaults to 8).
* The mouse cursor will automatically snap to the tile or pixel position you move to with the arrow keys, allowing for easier placement of items (such as calendars and furniture).
* When you turn your character or move, the cursor will snap to the tile in the direction you are facing (as per the old behavior). This preserves the mod's original functionality.
* You can enable relative cursor lock (default key is l). This allows you to keep the mouse at a set position relative to you as you move. This would be equivalent to moving the mouse somewhere on screen and moving your character without touching the mouse.
* You can configure the precise pixel movement amount as well as whether or not to limit the tile cursor to visible tiles only.