### PR TITLE
Misc fixes

### DIFF
--- a/stardew-access/Features/CurrentPlayer.cs
+++ b/stardew-access/Features/CurrentPlayer.cs
@@ -96,15 +96,10 @@ namespace stardew_access.Features
 
                 int minutes = timeOfDay % 100;
                 int hours = timeOfDay / 100;
-                string amOrpm = "A M";
-                if (hours >= 12)
-                {
-                    amOrpm = "P M";
-                    if (hours > 12)
-                        hours -= 12;
-                }
-
-                return $"{hours}:{minutes} {amOrpm}";
+                string amOrpm = hours / 12 == 1 ? "PM" : "AM";
+                hours = hours % 12;
+                if (hours == 0) hours = 12;
+                return $"{hours}:{minutes:00} {amOrpm}";
             }
         }
 

--- a/stardew-access/Features/TileInfo.cs
+++ b/stardew-access/Features/TileInfo.cs
@@ -47,16 +47,15 @@ namespace stardew_access.Features
             (string? name, CATEGORY category) staticTile = MainClass.STiles.getStaticTileInfoAtWithCategory(x, y);
             string? bush = getBushAtTile(x, y, lessInfo);
 
-            if (Game1.currentLocation.isCharacterAtTile(tile) != null)
+            if (Game1.currentLocation.isCharacterAtTile(tile) is NPC npc)
             {
-                NPC npc = Game1.currentLocation.isCharacterAtTile(tile);
-                toReturn = npc.displayName;
+                                toReturn = npc.displayName;
                 if (npc.isVillager() || npc.CanSocialize)
                     category = CATEGORY.Farmers;
                 else
                     category = CATEGORY.NPCs;
             }
-            else if (farmAnimal != null)
+                        else if (farmAnimal != null)
             {
                 toReturn = farmAnimal;
                 category = CATEGORY.FarmAnimals;
@@ -408,7 +407,11 @@ namespace stardew_access.Features
             }
             else if (Game1.currentLocation is Beach beach)
             {
-                if (x == 58 && y == 13)
+                                if (MainClass.ModHelper.Reflection.GetField<NPC>(beach, "oldMariner").GetValue() is NPC mariner && mariner.getTileLocation() == new Vector2(x, y))
+                {
+                    return (CATEGORY.NPCs, "Old Mariner");
+                }
+                else if (x == 58 && y == 13)
                 {
                     if (!beach.bridgeFixed.Value)
                         return (CATEGORY.Interactables, "Repair Bridge");

--- a/stardew-access/Features/TileInfo.cs
+++ b/stardew-access/Features/TileInfo.cs
@@ -49,13 +49,13 @@ namespace stardew_access.Features
 
             if (Game1.currentLocation.isCharacterAtTile(tile) is NPC npc)
             {
-                                toReturn = npc.displayName;
+                toReturn = npc.displayName;
                 if (npc.isVillager() || npc.CanSocialize)
                     category = CATEGORY.Farmers;
                 else
                     category = CATEGORY.NPCs;
             }
-                        else if (farmAnimal != null)
+            else if (farmAnimal != null)
             {
                 toReturn = farmAnimal;
                 category = CATEGORY.FarmAnimals;
@@ -300,7 +300,11 @@ namespace stardew_access.Features
         /// <br/>name: This is the name of the tile. Default to null if the tile tile has nothing on it.</returns>
         public static (CATEGORY? category, string? name) getDynamicTilesInfo(int x, int y, bool lessInfo = false)
         {
-            if (Game1.currentLocation is Farm farm)
+            if (Game1.currentLocation.orePanPoint != Point.Zero && Game1.currentLocation.orePanPoint == new Point(x, y))
+            {
+                return (CATEGORY.Interactables, "panning spot");
+            }
+            else if (Game1.currentLocation is Farm farm)
             {
                 if (farm.GetMainMailboxPosition().X == x && farm.GetMainMailboxPosition().Y == y)
                     return (CATEGORY.Interactables, "Mail box");
@@ -407,7 +411,7 @@ namespace stardew_access.Features
             }
             else if (Game1.currentLocation is Beach beach)
             {
-                                if (MainClass.ModHelper.Reflection.GetField<NPC>(beach, "oldMariner").GetValue() is NPC mariner && mariner.getTileLocation() == new Vector2(x, y))
+                if (MainClass.ModHelper.Reflection.GetField<NPC>(beach, "oldMariner").GetValue() is NPC mariner && mariner.getTileLocation() == new Vector2(x, y))
                 {
                     return (CATEGORY.NPCs, "Old Mariner");
                 }


### PR DESCRIPTION
This fixes a few issues:

* Times before 6 AM are no longer read as "PM"
* Removed space between the letters of AM and PM
* Times are now correctly formatted ("6:0 AM" becomes "6:00 AM" for example)
* The Old Mariner on the beach is now included in the NPCs category when he is there.
* Ore panning spots are now listed in the interactables category.