### PR TITLE
Chat And Notification Improvements

### DIFF
--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -18,6 +18,11 @@ internal class GameStateNarrator : FeatureBase
 
     private static GameStateNarrator? instance;
 
+    /// <summary>
+    /// Stores the last 9 spoken hud messages.
+    /// </summary>
+    public static List<string> HudMessagesBuffer = new();
+
     public new static GameStateNarrator Instance
     {
         get
@@ -123,8 +128,9 @@ internal class GameStateNarrator : FeatureBase
                     if (hudMessageQueryKey != searchQuery)
                     {
                         hudMessageQueryKey = searchQuery;
-
                         MainClass.ScreenReader.Say(toSpeak, true);
+                        HudMessagesBuffer.Add(toSpeak);
+                        if (HudMessagesBuffer.Count > 9) HudMessagesBuffer.RemoveAt(0);
                     }
                 }
             }

--- a/stardew-access/Patches/MiscPatches/ChatBoxPatch.cs
+++ b/stardew-access/Patches/MiscPatches/ChatBoxPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Microsoft.Xna.Framework.Input;
+using stardew_access.Features;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -27,9 +28,10 @@ internal class ChatBoxPatch : IPatch
     private static bool KeyboardDispatcher_RecieveTextInputPatch()
     {
         if (!isChatBoxActive) return true;
-        
+
         bool isLeftAltPressed = Game1.input.GetKeyboardState().IsKeyDown(Keys.LeftAlt);
-        if (!isLeftAltPressed) return true;
+        bool isRightAltPressed = Game1.input.GetKeyboardState().IsKeyDown(Keys.RightAlt);
+        if (!isLeftAltPressed && !isRightAltPressed) return true;
 
         return false;
     }
@@ -42,11 +44,12 @@ internal class ChatBoxPatch : IPatch
             {
                 isChatBoxActive = true;
                 bool isLeftAltPressed = Game1.input.GetKeyboardState().IsKeyDown(Keys.LeftAlt);
+                bool isRightAltPressed = Game1.input.GetKeyboardState().IsKeyDown(Keys.RightAlt);
 
                 bool isPrevButtonPressed = MainClass.Config.ChatMenuNextKey.JustPressed();
                 bool isNextButtonPressed = MainClass.Config.ChatMenuPreviousKey.JustPressed();
 
-                if (isLeftAltPressed && !isChatRunning)
+                if ((isLeftAltPressed || isRightAltPressed) && !isChatRunning)
                 {
                     int pressedNumKey = -1;
                     foreach (var key in Game1.input.GetKeyboardState().GetPressedKeys())
@@ -68,12 +71,23 @@ internal class ChatBoxPatch : IPatch
                         if (pressedNumKey != -1) break;
                     }
 
-                    if (pressedNumKey != -1 && ___messages.Count >= pressedNumKey)
+                    if (pressedNumKey != -1)
                     {
-                        isChatRunning = true;
-                        MainClass.ScreenReader.Say(GetMessage(___messages[^pressedNumKey]), true);
-                        Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
+                        if (isLeftAltPressed && ___messages.Count >= pressedNumKey)
+                        {
+                            isChatRunning = true;
+                            MainClass.ScreenReader.Say(GetMessage(___messages[^pressedNumKey]), true);
+                            Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
+                        }
+
+                        if (isRightAltPressed && GameStateNarrator.HudMessagesBuffer.Count >= pressedNumKey)
+                        {
+                            isChatRunning = true;
+                            MainClass.ScreenReader.Say(GameStateNarrator.HudMessagesBuffer[^pressedNumKey], true);
+                            Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
+                        }
                     }
+
                     return;
                 }
 

--- a/stardew-access/Patches/MiscPatches/ChatBoxPatch.cs
+++ b/stardew-access/Patches/MiscPatches/ChatBoxPatch.cs
@@ -1,80 +1,88 @@
 ﻿using HarmonyLib;
-using Microsoft.Xna.Framework;
 using StardewValley.Menus;
 
-namespace stardew_access.Patches
+namespace stardew_access.Patches;
+
+internal class ChatBoxPatch : IPatch
 {
-    internal class ChatBoxPatch : IPatch
+    private static int currentChatMessageIndex = 0;
+    private static string prevTextBoxMessage = "";
+    private static bool isChatRunning = false;
+
+    public void Apply(Harmony harmony)
     {
-        private static int currentChatMessageIndex = 0;
-        private static bool isChatRunning = false;
+        harmony.Patch(
+           original: AccessTools.DeclaredMethod(typeof(ChatBox), "update"),
+           postfix: new HarmonyMethod(typeof(ChatBoxPatch), nameof(ChatBoxPatch.UpdatePatch))
+        );
+    }
 
-        public void Apply(Harmony harmony)
+    private static void UpdatePatch(ChatBox __instance, List<ChatMessage> ___messages)
+    {
+        try
         {
-            harmony.Patch(
-                    original: AccessTools.Method(typeof(ChatBox), nameof(ChatBox.update), new Type[] { typeof(GameTime) }),
-                    postfix: new HarmonyMethod(typeof(ChatBoxPatch), nameof(ChatBoxPatch.UpdatePatch))
-                );
-        }
-
-        private static void UpdatePatch(ChatBox __instance, List<ChatMessage> ___messages)
-        {
-            try
+            if (__instance.chatBox.Selected)
             {
-                string toSpeak = " ";
+                bool isPrevButtonPressed = MainClass.Config.ChatMenuNextKey.JustPressed();
+                bool isNextButtonPressed = MainClass.Config.ChatMenuPreviousKey.JustPressed();
 
-                if (__instance.chatBox.Selected)
+                if (isNextButtonPressed && !isChatRunning)
                 {
-                    bool isPrevButtonPressed = MainClass.Config.ChatMenuNextKey.JustPressed();
-                    bool isNextButtonPressed = MainClass.Config.ChatMenuPreviousKey.JustPressed();
-
-                    if (___messages.Count <= 0) return;
-
-                    #region To narrate previous and next chat messages
-                    if (isNextButtonPressed && !isChatRunning)
-                    {
-                        isChatRunning = true;
-                        CycleThroughChatMessages(true, ___messages);
-                        Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
-                    }
-                    else if (isPrevButtonPressed && !isChatRunning)
-                    {
-                        isChatRunning = true;
-                        CycleThroughChatMessages(false, ___messages);
-                        Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
-                    }
-                    #endregion
+                    isChatRunning = true;
+                    CycleThroughChatMessages(false, ___messages);
+                    Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
                 }
-                else if (___messages.Count > 0)
+                else if (isPrevButtonPressed && !isChatRunning)
                 {
-                    #region To narrate latest chat message
-                    ___messages[^1].message.ForEach(message =>
+                    isChatRunning = true;
+                    CycleThroughChatMessages(true, ___messages);
+                    Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
+                }
+
+                Log.Info($"{__instance.chatBox.Text}");
+                if (prevTextBoxMessage != __instance.chatBox.Text)
+                {
+                    prevTextBoxMessage = __instance.chatBox.Text;
+                    MainClass.ScreenReader.Say(prevTextBoxMessage, true);
+                }
+            }
+            else
+            {
+                currentChatMessageIndex = 0;
+                if (___messages.Count > 0)
+                {
+                    string toSpeak = GetMessage(___messages[^1]);
+                    if (!string.IsNullOrWhiteSpace(toSpeak))
                     {
-                        toSpeak += $"{message.message}, ";
-                    });
-                    if (toSpeak != " ")
                         MainClass.ScreenReader.SayWithChatChecker(toSpeak, false);
-                    #endregion
+                    }
                 }
             }
-            catch (Exception e)
-            {
-                Log.Error($"An error occurred in chat box patch:\n{e.Message}\n{e.StackTrace}");
-            }
         }
-
-        private static void CycleThroughChatMessages(bool increase, List<ChatMessage> ___messages)
+        catch (Exception e)
         {
-            string toSpeak = " ";
-
-            currentChatMessageIndex = (increase) ? (Math.Min(currentChatMessageIndex + 1, ___messages.Count - 1)) : (currentChatMessageIndex = Math.Max(currentChatMessageIndex - 1, 0));
-
-            ___messages[currentChatMessageIndex].message.ForEach(message =>
-            {
-                toSpeak += $"{message.message}, ";
-            });
-
-            MainClass.ScreenReader.Say(toSpeak, true);
+            Log.Error($"An error occurred in chat box patch:\n{e.Message}\n{e.StackTrace}");
         }
+    }
+
+    private static void CycleThroughChatMessages(bool prev, List<ChatMessage> ___messages)
+    {
+        if (___messages.Count <= 0) return;
+
+        currentChatMessageIndex = prev
+            ? Math.Min(currentChatMessageIndex + 1, ___messages.Count)
+            : Math.Max(currentChatMessageIndex - 1, 1);
+
+        MainClass.ScreenReader.Say(GetMessage(___messages[^currentChatMessageIndex]), true);
+    }
+
+    private static string GetMessage(ChatMessage chatMessage)
+    {
+        if (chatMessage.message.Count <= 1)
+            return chatMessage.message[0].message;
+
+        string toReturn = "";
+        chatMessage.message.ForEach(chatSnippet => toReturn += $"{chatSnippet.message}, ");
+        return toReturn;
     }
 }

--- a/stardew-access/Patches/MiscPatches/ChatBoxPatch.cs
+++ b/stardew-access/Patches/MiscPatches/ChatBoxPatch.cs
@@ -1,4 +1,6 @@
 ﻿using HarmonyLib;
+using Microsoft.Xna.Framework.Input;
+using StardewValley;
 using StardewValley.Menus;
 
 namespace stardew_access.Patches;
@@ -23,8 +25,41 @@ internal class ChatBoxPatch : IPatch
         {
             if (__instance.chatBox.Selected)
             {
+                bool isLeftAltPressed = Game1.input.GetKeyboardState().IsKeyDown(Keys.LeftAlt);
+
                 bool isPrevButtonPressed = MainClass.Config.ChatMenuNextKey.JustPressed();
                 bool isNextButtonPressed = MainClass.Config.ChatMenuPreviousKey.JustPressed();
+
+                if (isLeftAltPressed && !isChatRunning)
+                {
+                    int pressedNumKey = -1;
+                    foreach (var key in Game1.input.GetKeyboardState().GetPressedKeys())
+                    {
+                        pressedNumKey = key switch
+                        {
+                            Keys.NumPad1 or Keys.D1 => 1,
+                            Keys.NumPad2 or Keys.D2 => 2,
+                            Keys.NumPad3 or Keys.D3 => 3,
+                            Keys.NumPad4 or Keys.D4 => 4,
+                            Keys.NumPad5 or Keys.D5 => 5,
+                            Keys.NumPad6 or Keys.D6 => 6,
+                            Keys.NumPad7 or Keys.D7 => 7,
+                            Keys.NumPad8 or Keys.D8 => 8,
+                            Keys.NumPad9 or Keys.D9 => 9,
+                            _ => -1,
+                        };
+
+                        if (pressedNumKey != -1) break;
+                    }
+
+                    if (pressedNumKey != -1 && ___messages.Count >= pressedNumKey)
+                    {
+                        isChatRunning = true;
+                        MainClass.ScreenReader.Say(GetMessage(___messages[^pressedNumKey]), true);
+                        Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
+                    }
+                    return;
+                }
 
                 if (isNextButtonPressed && !isChatRunning)
                 {
@@ -39,7 +74,7 @@ internal class ChatBoxPatch : IPatch
                     Task.Delay(200).ContinueWith(_ => { isChatRunning = false; });
                 }
 
-                Log.Info($"{__instance.chatBox.Text}");
+                // Log.Info($"{__instance.chatBox.Text}");
                 if (prevTextBoxMessage != __instance.chatBox.Text)
                 {
                     prevTextBoxMessage = __instance.chatBox.Text;

--- a/stardew-access/Patches/MiscPatches/Game1Patch.cs
+++ b/stardew-access/Patches/MiscPatches/Game1Patch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using stardew_access.Utils;
 using StardewModdingAPI;
 using StardewValley;
 
@@ -55,6 +56,12 @@ namespace stardew_access.Patches
 
                 if (!Game1.player.isMoving())
                     return true;
+
+                if (cueName is "grassyStep" or "sandyStep" or "snowyStep" or "stoneStep" or "thudStep" or "woodyStep"
+                        && TileInfo.IsCollidingAtTile(Game1.currentLocation, (int)CurrentPlayer.FacingTile.X, (int)CurrentPlayer.FacingTile.Y))
+                {
+                    return false;
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- Use `LeftAlt + num keys` to speak the last 9 chat messages.
- Similarly, use `RightAlt + num kes` to speak the last 9 notifications or hud messages.
- Improved message reading with `page up` and `page down`.
- Fixed footsteps not stopping bug.