### PR TITLE
Minor documentation update

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,8 +3,7 @@
 This page contains the list of all commands added by the mod.
 You can install the [Chat Commands](https://www.nexusmods.com/stardewvalley/mods/2092) mod which will enable entering
 the commands from the in-game chat box instead of using the terminal.
-For a list of commands added SMAPI, you can visit the
-page [here](https://stardewvalleywiki.com/Modding:Console_commands).
+For a list of commands added by SMAPI, you can visit the [Console commands](https://stardewvalleywiki.com/Modding:Console_commands) page.
 
 ## Table Of Contents
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,10 +2,10 @@
 
 The mod can be configured by a `config.json` file that can be found in the mod's folder (if you can't find it than try
 running game once).
-The file is a json type so you can edit it using any text editor on your computer or you can use onlne json editors
+The file is a .json type so you can edit it using any text editor on your computer or you can use online json editors
 like [Json Editor Online](https://jsoneditoronline.org/).
 For the list of button codes
-visit [this page](https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Button_codes).
+visit [Player Guide/Key Bindings](https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Button_codes).
 
 ## Table Of Contents
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,7 @@
 
 ### Read Tile
 
-Reads the name and information about the tile the player is currently looking (not the one the player is standing on).
+Reads the name and information about the tile the player is currently facing (not the one the player is standing on).
 This feature uses in-game methods/properties to get the name and information of the object on the tile.
 Many tiles don't have textual information so for that, the mod uses a json file to get the name of the tile.
 You can find this file in the `assets/TilesData` folder by the name `tiles.json`.
@@ -66,7 +66,7 @@ See related: [keybindings](keybindings.md#object-tracker-keys), [configs](config
 When enabled, the player moves tile by tile instead of freely.
 This feature is most helpful when planting/harvesting crops or in any case where precise movement is required.
 
-_Note: If in case you encounter the player moving more than one step or the speed being faster than usual,
+_Note: In case you encounter the player moving more than one step or the speed being faster than usual,
 try reducing the speed of grid movement from the config._
 
 See related: [keybindings](keybindings.md#grid-movement-keys), [configs](config.md#grid-movement-configs).

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -21,7 +21,7 @@ This assumes that you have installed the game and the mod as well, go to the [se
 Once the game is loaded and you have entered the title screen, select the new game button to open the new game menu (also known as the character customization menu).
 You can use wasd keys to navigate through the menus and `Control + Enter` or `[` key to select a button or other UI elements.
 Once you're in the new game menu, use the left and right arrow keys to go to next or previous element and again, `Control + Enter` or `[` key to select it.
-Check the full list of keybindings in this menu [here](keybindings.md#new-game-or-character-customization-menu-keys).
+Check the [full list of character customization menu keybindings](keybindings.md#new-game-or-character-customization-menu-keys) .
 In case of a text box, first select the element with `[` or `Control + Enter` and then type the text you want and press `Escape` key to unselect the text box.
 And in case of a slider, use up and down arrow keys or page up and page down keys to change the value.
 By default, options related to character appearance are hidden, press `Left Control + Space` to make it visible and then you can edit the farmer's appearance.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,8 @@
 ## Requirements
 
 1. [SMAPI](#smapi-setup)
-2. [Project Fluent](#installing-project-fluent)
+2. [Kokoro](#installing-kokoro-and-project-fluent)
+3. [Project Fluent](#installing-kokoro-and-project-fluent)
 
 ### SMAPI setup
 
@@ -121,15 +122,16 @@ _(Note that this gets automatically taken care of for the xbox version while ins
 2. Extract the .zip file somewhere (Your downloads folder is fine).
 3. Double-click `install on Mac.command`, and follow the on-screen instructions.
 
-### Installing Project Fluent
+### Installing Kokoro and Project Fluent
 
-As of v1.5.0, the [Project Fluent mod](https://www.nexusmods.com/stardewvalley/mods/12638) is now a dependency for
+As of v1.5.0, [Kokoro](https://www.nexusmods.com/stardewvalley/mods/15682) and [Project Fluent ](https://www.nexusmods.com/stardewvalley/mods/12638) are now dependencies for
 stardew access and as such, the mod won't run without
-it.
+them.
 Project Fluent is mainly used for providing a way to have translation mods for stardew access and also the ability to
 use [Mozilla's project fluent](https://projectfluent.org/) instead of regular json for translation files.
+Kokoro is a core mod for many of [Shockah's](https://www.nexusmods.com/stardewvalley/users/133612513) mods and is required for Project Fluent to work.
 
-Installation of Project Fluent is essentially the same as installing any other mod, here are the steps:
+Installation of Project Fluent and Kokoro is essentially the same as installing any other mod, here are the steps:
 
 1. Download the v1.1.0 of Project Fluent
    from [this Nexus direct link](https://www.nexusmods.com/stardewvalley/mods/12638?tab=files&file_id=56519) ([login](https://users.nexusmods.com/auth/sign_in)
@@ -137,9 +139,11 @@ Installation of Project Fluent is essentially the same as installing any other m
    from [Github](https://github.com/Shockah/Stardew-Valley-Mods/releases/download/release%2Fproject-fluent%2F1.1.0/ProjectFluent.1.1.0.zip).
     - Do note that the Github link is only temporary and might get removed in future as the owner only publishes mod
       updates to Nexus.
-2. Extract the zip file and move it into the `Mods` folder in your game's folder.
+      2. Download the v3.0.0 of Kokoro from
+   [this Nexus direct link](https://www.nexusmods.com/stardewvalley/mods/15682?tab=files&file_id=82817)
+3. Extract both zip files and move the contents of each into the `Mods` folder in your game's folder.
 
-## Mod Installation
+## Stardew Access Installation
 
 1. Download the latest version from [Github](https://github.com/khanshoaib3/stardew-access/releases/latest) or
    from [Nexus](https://www.nexusmods.com/stardewvalley/mods/16205/?tab=files).
@@ -150,7 +154,7 @@ Installation of Project Fluent is essentially the same as installing any other m
 _In case you are experiencing any kinds of bugs, it is recommended that you install the debug zip.
 It will generate more stuff in the log helpful for debugging._
 
-## Updating The Mod
+## Updating Stardew Access
 
 To update you just need to delete or move the mod folder from the `Mods` folder to somewhere else and repeat the
 installation instruction from the previous section.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,9 +14,9 @@
                 * [For GOG Galaxy](#for-gog-galaxy)
         * [For Linux](#for-linux)
         * [For MacOS](#for-macos)
-    * [Installing Project Fluent](#installing-project-fluent)
-* [Mod Installation](#mod-installation)
-* [Updating The Mod](#updating-the-mod)
+    * [Installing Kokoro and Project Fluent](#installing-kokoro-and-project-fluent)
+* [Stardew Access Installation](#stardew-access-installation)
+* [Updating Stardew Access](#updating-stardew-access)
 * [Other Mods](#other-mods)
     * [Essentials](#essentials)
     * [Recommended](#recommended)
@@ -113,8 +113,8 @@ _(Note that this gets automatically taken care of for the xbox version while ins
 4. If you installed Steam through Flatpak, see these instructions:
 5. instructions for Flatpak
 6. Run the `install on Linux.sh` file, and follow the on-screen instructions.
-    - (If the installer asks for your game install path, see how to find your game
-      folder - [here](https://stardewvalleywiki.com/Modding:Player_Guide/Getting_Started#Find_your_game_folder).)
+    - (If the installer asks for your game install path, see how to
+       [find your game folder here](https://stardewvalleywiki.com/Modding:Player_Guide/Getting_Started#Find_your_game_folder).)
 
 #### For MacOS
 
@@ -139,7 +139,7 @@ Installation of Project Fluent and Kokoro is essentially the same as installing 
    from [Github](https://github.com/Shockah/Stardew-Valley-Mods/releases/download/release%2Fproject-fluent%2F1.1.0/ProjectFluent.1.1.0.zip).
     - Do note that the Github link is only temporary and might get removed in future as the owner only publishes mod
       updates to Nexus.
-      2. Download the v3.0.0 of Kokoro from
+2. Download the v3.0.0 of Kokoro from
    [this Nexus direct link](https://www.nexusmods.com/stardewvalley/mods/15682?tab=files&file_id=82817)
 3. Extract both zip files and move the contents of each into the `Mods` folder in your game's folder.
 

--- a/stardew-access/compiled-docs/commands.html
+++ b/stardew-access/compiled-docs/commands.html
@@ -3,8 +3,7 @@
 <p>This page contains the list of all commands added by the mod.
 You can install the <a href="https://www.nexusmods.com/stardewvalley/mods/2092">Chat Commands</a> mod which will enable entering
 the commands from the in-game chat box instead of using the terminal.
-For a list of commands added SMAPI, you can visit the
-page <a href="https://stardewvalleywiki.com/Modding:Console_commands">here</a>.</p>
+For a list of commands added by SMAPI, you can visit the <a href="https://stardewvalleywiki.com/Modding:Console_commands">Console commands</a> page.</p>
 
 <h2 id="table-of-contents">Table Of Contents</h2>
 

--- a/stardew-access/compiled-docs/config.html
+++ b/stardew-access/compiled-docs/config.html
@@ -2,10 +2,10 @@
 
 <p>The mod can be configured by a <code>config.json</code> file that can be found in the mod’s folder (if you can’t find it than try
 running game once).
-The file is a json type so you can edit it using any text editor on your computer or you can use onlne json editors
+The file is a .json type so you can edit it using any text editor on your computer or you can use online json editors
 like <a href="https://jsoneditoronline.org/">Json Editor Online</a>.
 For the list of button codes
-visit <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Button_codes">this page</a>.</p>
+visit <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Button_codes">Player Guide/Key Bindings</a>.</p>
 
 <h2 id="table-of-contents">Table Of Contents</h2>
 
@@ -107,7 +107,7 @@ visit <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#B
       <td>Toggle speaking watered or unwatered for crops.</td>
     </tr>
     <tr>
-      <td>ReadTileDebug</td>
+      <td>ReadTileIndexes</td>
       <td>false</td>
       <td>Toggle speaking tile indexes with other info.</td>
     </tr>
@@ -612,7 +612,7 @@ visit <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#B
   "ReadStandingTileKey": "LeftAlt + J",
   "ReadFlooring": false,
   "WateredToggle": true,
-  "ReadTileDebug": false,
+  "ReadTileIndexes": false,
   "TileCursorUpKey": "Up",
   "TileCursorRightKey": "Right",
   "TileCursorDownKey": "Down",

--- a/stardew-access/compiled-docs/features.html
+++ b/stardew-access/compiled-docs/features.html
@@ -23,7 +23,7 @@
 
 <h3 id="read-tile">Read Tile</h3>
 
-<p>Reads the name and information about the tile the player is currently looking (not the one the player is standing on).
+<p>Reads the name and information about the tile the player is currently facing (not the one the player is standing on).
 This feature uses in-game methods/properties to get the name and information of the object on the tile.
 Many tiles don’t have textual information so for that, the mod uses a json file to get the name of the tile.
 You can find this file in the <code>assets/TilesData</code> folder by the name <code>tiles.json</code>.
@@ -73,7 +73,7 @@ This feature also allows to auto navigate to an object or speaks it’s relative
 <p>When enabled, the player moves tile by tile instead of freely.
 This feature is most helpful when planting/harvesting crops or in any case where precise movement is required.</p>
 
-<p><em>Note: If in case you encounter the player moving more than one step or the speed being faster than usual,
+<p><em>Note: In case you encounter the player moving more than one step or the speed being faster than usual,
 try reducing the speed of grid movement from the config.</em></p>
 
 <p>See related: <a href="keybindings.html#grid-movement-keys">keybindings</a>, <a href="config.html#grid-movement-configs">configs</a>.</p>

--- a/stardew-access/compiled-docs/setup.html
+++ b/stardew-access/compiled-docs/setup.html
@@ -25,11 +25,11 @@
           <li><a href="#for-macos">For MacOS</a></li>
         </ul>
       </li>
-      <li><a href="#installing-project-fluent">Installing Project Fluent</a></li>
+      <li><a href="#installing-kokoro-and-project-fluent">Installing Kokoro and Project Fluent</a></li>
     </ul>
   </li>
-  <li><a href="#mod-installation">Mod Installation</a></li>
-  <li><a href="#updating-the-mod">Updating The Mod</a></li>
+  <li><a href="#stardew-access-installation">Stardew Access Installation</a></li>
+  <li><a href="#updating-stardew-access">Updating Stardew Access</a></li>
   <li><a href="#other-mods">Other Mods</a>
     <ul>
       <li><a href="#essentials">Essentials</a></li>
@@ -45,7 +45,8 @@
 
 <ol>
   <li><a href="#smapi-setup">SMAPI</a></li>
-  <li><a href="#installing-project-fluent">Project Fluent</a></li>
+  <li><a href="#installing-kokoro-and-project-fluent">Kokoro</a></li>
+  <li><a href="#installing-kokoro-and-project-fluent">Project Fluent</a></li>
 </ol>
 
 <h3 id="smapi-setup">SMAPI setup</h3>
@@ -154,8 +155,8 @@ running <code>sudo apt install libssl1.1</code> on a terminal).</li>
   <li>instructions for Flatpak</li>
   <li>Run the <code>install on Linux.sh</code> file, and follow the on-screen instructions.
     <ul>
-      <li>(If the installer asks for your game install path, see how to find your game
-folder - <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Getting_Started#Find_your_game_folder">here</a>.)</li>
+      <li>(If the installer asks for your game install path, see how to
+ <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Getting_Started#Find_your_game_folder">find your game folder here</a>.)</li>
     </ul>
   </li>
 </ol>
@@ -168,15 +169,16 @@ folder - <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Getting_Sta
   <li>Double-click <code>install on Mac.command</code>, and follow the on-screen instructions.</li>
 </ol>
 
-<h3 id="installing-project-fluent">Installing Project Fluent</h3>
+<h3 id="installing-kokoro-and-project-fluent">Installing Kokoro and Project Fluent</h3>
 
-<p>As of v1.5.0, the <a href="https://www.nexusmods.com/stardewvalley/mods/12638">Project Fluent mod</a> is now a dependency for
+<p>As of v1.5.0, <a href="https://www.nexusmods.com/stardewvalley/mods/15682">Kokoro</a> and <a href="https://www.nexusmods.com/stardewvalley/mods/12638">Project Fluent </a> are now dependencies for
 stardew access and as such, the mod won’t run without
-it.
+them.
 Project Fluent is mainly used for providing a way to have translation mods for stardew access and also the ability to
-use <a href="https://projectfluent.org/">Mozilla’s project fluent</a> instead of regular json for translation files.</p>
+use <a href="https://projectfluent.org/">Mozilla’s project fluent</a> instead of regular json for translation files.
+Kokoro is a core mod for many of <a href="https://www.nexusmods.com/stardewvalley/users/133612513">Shockah’s</a> mods and is required for Project Fluent to work.</p>
 
-<p>Installation of Project Fluent is essentially the same as installing any other mod, here are the steps:</p>
+<p>Installation of Project Fluent and Kokoro is essentially the same as installing any other mod, here are the steps:</p>
 
 <ol>
   <li>Download the v1.1.0 of Project Fluent
@@ -188,10 +190,12 @@ from <a href="https://github.com/Shockah/Stardew-Valley-Mods/releases/download/r
 updates to Nexus.</li>
     </ul>
   </li>
-  <li>Extract the zip file and move it into the <code>Mods</code> folder in your game’s folder.</li>
+  <li>Download the v3.0.0 of Kokoro from
+<a href="https://www.nexusmods.com/stardewvalley/mods/15682?tab=files&amp;file_id=82817">this Nexus direct link</a></li>
+  <li>Extract both zip files and move the contents of each into the <code>Mods</code> folder in your game’s folder.</li>
 </ol>
 
-<h2 id="mod-installation">Mod Installation</h2>
+<h2 id="stardew-access-installation">Stardew Access Installation</h2>
 
 <ol>
   <li>Download the latest version from <a href="https://github.com/khanshoaib3/stardew-access/releases/latest">Github</a> or
@@ -204,7 +208,7 @@ from <a href="https://www.nexusmods.com/stardewvalley/mods/16205/?tab=files">Nex
 <p><em>In case you are experiencing any kinds of bugs, it is recommended that you install the debug zip.
 It will generate more stuff in the log helpful for debugging.</em></p>
 
-<h2 id="updating-the-mod">Updating The Mod</h2>
+<h2 id="updating-stardew-access">Updating Stardew Access</h2>
 
 <p>To update you just need to delete or move the mod folder from the <code>Mods</code> folder to somewhere else and repeat the
 installation instruction from the previous section.</p>


### PR DESCRIPTION
Updates to headings and hyperlinks to improve clarity when reading the documentation with a screen reader. Many links were labeled "here" which can be confusing when navigating via links without sight. There was also one single typo, so that was fixed.

Additional instructions for installing Kokoro were added to setup. While this requirement is listed on the Nexus page for Project Fluent, its presence is not at all obvious to screen reader users, especially novices to screen readers and/or the Nexus website. Nexus in general is also extremely frustrating to use. Presenting all the information from the outset will result in a less frustrating and more straightforward experience for all users.