### PR TITLE
Major guides page revamp

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ If you are a mod developer and want to integrate your mod with stardew access th
 - [Keybindings](keybindings.md)
 - [Commands](commands.md)
 - [Configs](config.md)
-- [Guides](https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md)
+- [Guides](guides.md)
 
 ## Useful Links
 
@@ -46,7 +46,7 @@ Made with [contrib.rocks](https://contrib.rocks).
 ## Translations
 
 As of v1.5.0, the mod has been fully internationalised.
-Follow [this](https://github.com/khanshoaib3/stardew-access/issues/182) issue page to track the progress of
+Follow [this issue page](https://github.com/khanshoaib3/stardew-access/issues/182) to track the progress of
 translations currently in the works and/or if you want to provide translation for your language.
 
 ## Contact Us

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -75,4 +75,4 @@ For a list of commands added by SMAPI, you can visit the [Console commands](http
 - [Features](features.md)
 - [Keybindings](keybindings.md)
 - [Configs](config.md)
-- [Guides](https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md)
+- [Guides](guides.md)

--- a/docs/compiler_script.rb
+++ b/docs/compiler_script.rb
@@ -4,7 +4,7 @@
 # The converted html content is saved in the stardew-access/compiled-docs directory.
 # Use the following command to execute this script:
 #   ruby compiler_script.rb
-# Note that you have to cd into the docs directory before running the above command
+2# Note that you have to cd into the docs directory before running the above command
 
 require 'kramdown'
 
@@ -12,7 +12,6 @@ puts "Searching for files to convert/compile to html...";
 
 markdown_files = Dir.glob("*.md")
 markdown_files.each do|file_name|
-  next if file_name == "guides.md"
   puts "Found: " + file_name + ", compiling..."
 
   source_file_object = File.open(file_name, "r")

--- a/docs/compiler_script.rb
+++ b/docs/compiler_script.rb
@@ -4,7 +4,7 @@
 # The converted html content is saved in the stardew-access/compiled-docs directory.
 # Use the following command to execute this script:
 #   ruby compiler_script.rb
-2# Note that you have to cd into the docs directory before running the above command
+# Note that you have to cd into the docs directory before running the above command
 
 require 'kramdown'
 
@@ -21,7 +21,6 @@ markdown_files.each do|file_name|
   file_contents = source_file_object.read()
   compiled_html_content = Kramdown::Document.new(file_contents).to_html
   compiled_html_content = compiled_html_content.gsub(".md", ".html")
-  compiled_html_content = compiled_html_content.gsub("guides.html", "guides.md")
   compiled_file_object.syswrite(compiled_html_content)
 
   puts "File " + file_name + " compiled and saved at: " + compiled_file_name

--- a/docs/config.md
+++ b/docs/config.md
@@ -258,8 +258,8 @@ This is the default value of the `config.json` file as per `v1.5.0`:
 ## Other Pages
 
 - [Readme](README.html)
-- [Setup](setup.html)
-- [Features](features.html)
-- [Keybindings](keybindings.html)
-- [Commands](commands.html)
-- [Guides](https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md)
+- [Setup](setup.md)
+- [Features](features.md)
+- [Keybindings](keybindings.md)
+- [Commands](commands.md)
+- [Guides](guides.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -257,7 +257,7 @@ This is the default value of the `config.json` file as per `v1.5.0`:
 
 ## Other Pages
 
-- [Readme](README.html)
+- [Readme](README.md)
 - [Setup](setup.md)
 - [Features](features.md)
 - [Keybindings](keybindings.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -103,4 +103,4 @@ See related: [commands](commands.md#radar-related), [configs](config.md#radar-co
 - [Keybindings](keybindings.md)
 - [Commands](commands.md)
 - [Configs](config.md)
-- [Guides](https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md)
+- [Guides](guides.md)

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -9,6 +9,10 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
 - [Creating a New Game](#creating-a-new-game)
 - [Saving Your Progress](#saving-your-progress)
 - [Using The Tile Viewer](#using-the-tile-viewer)
+- [Using The Object Tracker](#using-the-object-tracker)
+    - [Object Tracker](#object-tracker)
+    - [Object Tracker Favorites](#object-tracker-favorites)
+        - [Tracking Coordinates With Favorites](#tracking-coordinates-with-favorites)
 - [Buying and Selling](#buying-and-selling)
 - [Farming](#farming)
     - [Planting Crops](#planting-crops)
@@ -93,6 +97,38 @@ This will open a dialogue which provides you with various options:
     - Get more information about the selected tile
 
 This feature can be remapped to a controller/gamepad via the `config.json` file. More info available in [keybindings](keybindings.md#tile-viewer-keys) and [configs](config.md#tile-viewer-configs).
+
+## Using The Object Tracker
+
+The object tracker is an extremely helpful feature of Stardew Access. It lets you browse all of the items, NPCs, interactable items, and other points of interest on the current map. For a full list of keys and config options, check out the relevant sections in [keybinds](keybindings.md#object-tracker-keys) and [configs](config.md#object-tracker-configs).
+
+- [Object Tracker](#object-tracker)
+- [Object Tracker Favorites](#object-tracker-favorites)
+    - [Tracking Coordinates With Favorites](#tracking-coordinates-with-favorites)
+
+### Object Tracker
+
+The object tracker does two things: it lists all available objects in their respective categories, and it allows you to get their position and travel to them.
+Categories can be browsed with `left ctrl +pageUp` and `left ctrl + pageDown`. They are listed in alphabetical order, so "doors" will always come before "mine items" which will always come before "pending" which will always come before "resources" and so on.
+Not all categories will show up in all locations. The categories will only be visible if there is an object that fits that category on the current map. If you are in the town, the chances of seeing the "mine items" category will be very, very, very low.
+
+To browse objects within a category, use `pageUp` and `pageDown`. objects will appear within each category in the order of their proximity to you.
+IF you wish for them to show in alphabetical order, press `~ (tilde)` to toggle between proximity and alphabetical order. Note that each time the list refreshes, the order of objects will change if proximity is enabled, but categories will not change their order. If a category is visible but all items that pertain to it are removed from the map, that category will disappear once the object list refreshes. Your focus will be moved to a visible category.
+
+To get info on where an object is, use `home` or `end`. `home` will provide both relative directions (north 5) and absolute coordinates of the player and the object. `End` will only provide absolute coordinates. Pressing either of these keys will refresh the objects list.
+
+### Object Tracker Favorites
+
+You can set and manage favorite objects on a per-map basis. This portion of the object tracker uses the `left alt` and `right alt` keys interchangeably, so this guide will refer to them collectively as `alt`.
+
+Each map has a set of favorites which can be set by holding `alt` and double-tapping a number on the number row. Be sure to focus your object tracker on the object which you want to set as the favorite first. Use the numbers on the number row, 1 through 0 to access 10 favorites at a time.
+Once a favorite is set, double-tap that number while holding `alt` to travel to that object. To hear the object location, single-tap the respective number while holding `alt`. To erase a favorite object, triple-tap its respective number while holding `alt`.
+
+To access more than 10 favorite objects, hold `alt` and press `+ (plus)` or `- (minus)` to browse through favorite stacks. Each map can have up to several hundred stacks, giving you access to many thousands of favorites per map.
+
+#### Tracking coordinates With Favorites
+
+To track a specific tile coordinate, press `tab + ~` to toggle saving coordinates. When the feature is enabled, hold `alt` and double-tap the desired number on an empty favorite to save the coordinate. Don't worry about what object the object tracker is focused on. To stop saving coordinates and return to normal functionality, disable saving coordinates with the same keystroke.
 
 ## Buying and Selling
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -3,6 +3,15 @@
 This page provides guides for playing Stardew Valley with Stardew Access enabled. While Stardew Access attempts to provide its players feature parity with the base game, some activities must be performed differently and/or may not be obvious to new players. This page assumes that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the [setup page](setup.md).
 Information about the controls for Stardew Access and Stardew Valley can be found in [Keybindings](keybindings.md).
 
+## Guide Version
+
+**This guide file is up to date with Stardew Access [Release v1.5.1](https://github.com/khanshoaib3/stardew-access/releases/tag/v1.5.1).**
+
+To get the most current documentation, check the following links:
+
+- [Stable Release Documentation](https://github.com/khanshoaib3/stardew-access/tree/master/docs)
+- [Beta Release Documentation](https://github.com/khanshoaib3/stardew-access/tree/development/docs#introduction)
+
 ## Table Of Contents
 
 - [Key Terms and Controls](#key-terms-and-controls)
@@ -266,6 +275,8 @@ If you cannot move an animal to a new building, ensure that the following are tr
 3. You are selecting the correct building
 
 <!--todo: more animal guides probably-->
+
+<!--todo: mining guide-->
 
 ## Other Pages
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -9,6 +9,10 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
 - [Creating a New Game](#creating-a-new-game)
 - [Saving Your Progress](#saving-your-progress)
 - [Using The Tile Viewer](#using-the-tile-viewer)
+- [Farming](#farming)
+    - [Planting Crops](#planting-crops)
+    - [Growing Crops](#growing-crops)
+    - [Harvesting Crops](#harvesting-crops)
 - [Farm Buildings](#farm-buildings)
     - [Constructing Farm Buildings](#constructing-farm-buildings)
     - [Upgrading Farm Buildings](#upgrading-farm-buildings)
@@ -49,7 +53,7 @@ To use a text box, interact with it using left mouse click, type the desired tex
 To modify the value of a slider, use `up arrow` and `down arrow` or `pageUp` and `pageDown` while focused on the desired slider.
 Some controls allow you to cycle back and forth through a set of options. These controls appear in pairs, one immediately after the other and will include "previous" and "next" in their respective names. Focusing on them will announce the currently selected option. Pressing either will announce the newly-selected option. To hear the currently-selected option again, move focus off of the controls and then move focus onto them again.
 
-Character creation controls are shown by default. To toggle their visibility, Press `Left Control + Space`. This is where you will find sliders for options such as /hair color and eye color. Color sliders appear in sets of 3 and adjust hue, saturation, and value (brightness). They announce their current value in the same fashion as the "next" and "previous" pairs. Their individual values range from 0% to 99%. Below is an explanation of what each slider does. Note that the game may report different names for each unique color that results from a particular slider configuration.
+Character creation controls are shown by default. To toggle their visibility, Press `Left Control + Space`. This is where you will find sliders for options such as hair color and eye color. Color sliders appear in sets of 3 and adjust hue, saturation, and value (brightness). They announce their current value in the same fashion as the "next" and "previous" pairs. Their individual values range from 0% to 99%. Below is an explanation of what each slider does. Note that the game may report different names for each unique color that results from a particular slider configuration.
 
 - Hue spans through the color spectrum from red at the minimum, through the rainbow, and back to red at the maximum.
     - At 99% saturation and 99% value, Hue spans from 0% to 99% as follows: red, orange, yellow, green, blue, indigo, violet, magenta, red
@@ -89,9 +93,37 @@ This will open a dialogue which provides you with various options:
 
 This feature can be remapped to a controller/gamepad via the `config.json` file. More info available in [keybindings](keybindings.md#tile-viewer-keys) and [configs](config.md#tile-viewer-configs).
 
-<!--todo: Planting And Harvesting-->
-
 <!--todo: Buying And Selling Stuff-->
+
+## Farming
+
+Farming, including planting and harvesting crops, is the primary way to make money in Stardew Valley, especially in the early-game. The following guides will cover how to farm.
+
+- [Planting Crops](#planting-crops)
+- [Growing Crops](#growing-crops)
+- [Harvesting Crops](#harvesting-crops)
+
+### Planting Crops
+
+Once you have purchased seeds from Pierre's general store in the town (a.k.a) SeedShop) or otherwise obtained seeds, go to your farm and use your tools to clear a plot of land to plant them. Make sure to clear grass as well.
+Your scythe does not consume any of your energy. Once you have cleared sufficient land to plant your crops, use your hoe to till the soil.
+Next, use your watering can to water the soil and add any [fertilizer](https://stardewvalleywiki.com/Fertilizer) if desired to the soil.
+finally, place your crops in the soil. You may plant your crops before watering, but fertilizers **must** be placed before the crop is placed.
+Tilling individual tiles can be very tedious, so be sure to check Clint's shop in the town (a.k.a Blacksmith) for tool upgrades. Once you upgrade your hoe, you can hold down `tool button` and hoe several tiles at a time.
+
+### Growing crops
+
+Different crops will take different amounts of time to grow. Most crops will only grow during one season, however they will grow during any season in the greenhouse. Growing season and growing time are listed in Pierre's shop as well as on the item's tooltip in your inventory.
+Each season is 28 days long, and it's important to ensure your crop has enough time to grow. If your crop has not been harvested before the start of the next season, it will die unless it also grows in the new season. Most crops only grow in one season. It's important to water your crop daily. Unwatered crops will not die, but they will not grow that day.
+Each day has a chance of rain. If it rains, there is no need to water your crops as the rain will take care of it. Crops grown indoors or in the greenhouse must be watered regardless of rain. Check the TV in your farmhouse for next day's forecast.
+You can walk over most crops safely with the exception of crops that grow on a trellis. You cannot pass through trellis crops at all, so make sure you leave enough room to reach them.
+Some crops, such as green beans, hot peppers, and blueberries, will produce multiple harvests per crop. Once they mature, you can pick the first harvest and continue watering the crops daily as normal and producing more harvests until the end of the season.
+Lastly, you may craft [sprinklers](https://stardewvalleywiki.com/Sprinkler) in order to keep crops watered. There are several tiers of sprinklers which keep progressively more tiles watered.
+
+### Harvesting Crops
+
+To harvest a mature crop, walk up to the crop and press `action button` to harvest it. The tile will be emptied and another crop may be placed. If the crop produces multiple harvests, the crop will remain on the tile and you can continue to water it as normal.
+Be careful that you do not use your pickaxe on crops as doing so will destroy them, undoing all your hard work.
 
 ## Farm Buildings
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -9,6 +9,7 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
 - [Creating a New Game](#creating-a-new-game)
 - [Saving Your Progress](#saving-your-progress)
 - [Using The Tile Viewer](#using-the-tile-viewer)
+- [Buying and Selling](#buying-and-selling)
 - [Farming](#farming)
     - [Planting Crops](#planting-crops)
     - [Growing Crops](#growing-crops)
@@ -93,7 +94,26 @@ This will open a dialogue which provides you with various options:
 
 This feature can be remapped to a controller/gamepad via the `config.json` file. More info available in [keybindings](keybindings.md#tile-viewer-keys) and [configs](config.md#tile-viewer-configs).
 
-<!--todo: Buying And Selling Stuff-->
+## Buying and Selling
+
+Buying and selling is usually accomplished through shops which are scattered throughout the valley and run by various residents of the town. They all offer different products, services, and have slightly different interfaces but all involve very similar steps. Selling your crops, fish, artisan goods, etc. can either be done at a shop or by putting the items into the shipping bin on your farm.
+
+This guide will use Robin's shop as an example since Robin offers both products and services.
+
+To buy items:
+
+1. Enter the shop during business hours (these will vary from shop to shop. Pierre's is closed on Wednesdays) and approach the shop counter.
+2. Interact with the shop counter to open the shop dialogue.
+3. You can choose various options from the shop dialogue such as constructing farm buildings, upgrading your house, purchasing items, or leaving. Some shops May not offer options and only sell items. In that case, you will be placed immediately in the shop menu.
+4. Assuming you selected "shop" or entered a shop that only sells items, you will be placed in the shop menu which presents a list of items that are sold.
+5. To buy an item, select the desired item and use left mouse click. You can purchase 5 of an item by holding shift and using left mouse click.
+
+To sell items:
+
+1. follow the first 4 steps in the previous list.
+2. Move to your inventory items or press `I`
+3. Find the item you want to sell in your inventory. Only certain items may be sold at certain shops.
+4. Use `left mouse click` on the item to sell the entire stack. Use ` shift + left mouse click` to sell half the stack.
 
 ## Farming
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,77 +1,183 @@
 # Guides
 
-This page contains guides on how to use the mod to play the game.
-At the moment, the amount of guides is very few but hopefully this won't be the case by the next update.
+This page provides guides for playing Stardew Valley with Stardew Access enabled. While Stardew Access attempts to provide its players feature parity with the base game, some activities must be performed differently and/or may not be obvious to new players. This page assumes that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the [setup page](setup.md).
+Information about the controls for Stardew Access and Stardew Valley can be found in [Keybindings](keybindings.md).
 
 ## Table Of Contents
 
-- [Guides List](#guides-list)
-  - [Creating A New Game](#creating-a-new-game)
-  - [Saving The Progress](#saving-the-progress)
-  - [Using The Tile Viewer Feature](#using-the-tile-viewer-feature)
-  - [Constructing/Upgrading/Moving/Demolishing Buildings](#constructingupgradingmovingdemolishing-buildings)
-  - [Purchasing/Moving Farm Animals](#purchasingmoving-farm-animals)
+- [Key Terms and Controls](#key-terms-and-controls)
+- [Creating a New Game](#creating-a-new-game)
+- [Saving Your Progress](#saving-your-progress)
+- [Using The Tile Viewer](#using-the-tile-viewer)
+- [Farm Buildings](#farm-buildings)
+    - [Constructing Farm Buildings](#constructing-farm-buildings)
+    - [Upgrading Farm Buildings](#upgrading-farm-buildings)
+    - [Moving Farm Buildings](#moving-farm-buildings)
+    - [Demolishing Farm Buildings](#demolishing-farm-buildings)
+- [Farm Animals](#farm-animals)
+    - [Purchasing Farm Animals](#purchasing-farm-animals)
+    - [Moving Farm Animals](#moving-farm-animals)
 - [Other Pages](#other-pages)
 
-## Guides List
+## Key Terms and Controls
 
-### Creating A New Game
+- Controls
+    - Primary left click, `left ctrl + Enter` or secondary left click, `[` (left square bracket): Use one of these to emulate a left mouse-click
+    - primary right click, `left shift + enter` or secondary right click, `]` (right square bracket): emulate a right mouse click
+    - WASD: the four navigation keys used to navigate most of the game
+    - arrow keys: the four keys used to navigate certain menus
+    - [full list of keybindings](keybindings.md) .
+- Terms
+    - title screen: the first screen you encounter when launching the game.
+    - main menu: The menu immediately after the title screen which lets you create and load games.
+    - character creation menu: a menu that allows you to customize options for a new game
+    - construction menu: the menu for managing farm buildings accessed in Robin's shop
+    - dialogue: a menu pop-up which may present a short list of options or a character's speech
+    - shop counter dialogue: a dialogue which appears at the shop counters of businesses which offer more services than just item purchases
+    - shop counter menu: a menu accessed through the shop counters of businesses which allow you to purchase items
+    - grid: the portion of the map which is used for placing items and buildings
+    - tile: a square-shaped portion of the grid where items may be placed
+    - cursor: the pointer that sighted players use to select items and options
+    - tile cursor: a feature of the tile viewer which allows Stardew Access Players to move the cursor around on the map
+    - map interface: a screen which appears when purchasing farm animals or managing farm buildings
 
-This assumes that you have installed the game and the mod as well, go to the [setup page](setup.md) if you haven't already.
-Once the game is loaded and you have entered the title screen, select the new game button to open the new game menu (also known as the character customization menu).
-You can use wasd keys to navigate through the menus and `Control + Enter` or `[` key to select a button or other UI elements.
-Once you're in the new game menu, use the left and right arrow keys to go to next or previous element and again, `Control + Enter` or `[` key to select it.
-Check the [full list of character customization menu keybindings](keybindings.md#new-game-or-character-customization-menu-keys) .
-In case of a text box, first select the element with `[` or `Control + Enter` and then type the text you want and press `Escape` key to unselect the text box.
-And in case of a slider, use up and down arrow keys or page up and page down keys to change the value.
-By default, options related to character appearance are hidden, press `Left Control + Space` to make it visible and then you can edit the farmer's appearance.
-When you're done with the configuration, go to the `ok` button and select it which will trigger the intro cutscene (unless you've enabled `skip intro` option which will skip it).
+## Creating a New Game
 
-<!-- ### Navigating The World And The Menus -->
+Once you are on the  main menu, use the WASD keys to focus on different options. Select the "new game" button to the left of "load game" to open the new game menu (also known as the character customization menu).
+In the new game menu, use the right and left arrow keys to move to the next and previous elements, respectively.
+To use a text box, interact with it using left mouse click, type the desired text, and finally press `Escape` to stop interacting with it while focused on the desired text box.
+To modify the value of a slider, use `up arrow` and `down arrow` or `pageUp` and `pageDown` while focused on the desired slider.
+Some controls allow you to cycle back and forth through a set of options. These controls appear in pairs, one immediately after the other and will include "previous" and "next" in their respective names. Focusing on them will announce the currently selected option. Pressing either will announce the newly-selected option. To hear the currently-selected option again, move focus off of the controls and then move focus onto them again.
 
-### Saving The Progress
+Character creation controls are shown by default. To toggle their visibility, Press `Left Control + Space`. This is where you will find sliders for options such as /hair color and eye color. Color sliders appear in sets of 3 and adjust hue, saturation, and value (brightness). They announce their current value in the same fashion as the "next" and "previous" pairs. Their individual values range from 0% to 99%. Below is an explanation of what each slider does. Note that the game may report different names for each unique color that results from a particular slider configuration.
 
-To save the progress you have to sleep in the bed at the farm house and to do that, you have to walk into the bed which will open up a dialogue box asking to sleep.
-A thing to note is the you can't walk into the bed from the top or bottom as the headboard and footboard will block the path.
-You can also use `debug wh` or `debug warphome` command which will teleport you directly to the bed and then you can move one block to left and again move towards right to trigger the dialogue.
+- Hue spans through the color spectrum from red at the minimum, through the rainbow, and back to red at the maximum.
+    - At 99% saturation and 99% value, Hue spans from 0% to 99% as follows: red, orange, yellow, green, blue, indigo, violet, magenta, red
+- Saturation spans from none at the minimum to full saturation of the selected hue at maximum.
+    - At 0% hue and 99% value, 0% saturation is white and 99% saturation is bright red.
+- Value, also known as brightness, adjusts the brightness of the selected hue and saturation from black to full brightness.
+    - at 0% hue and 99% saturation, 0% value is black and 99% value is bright red. To achieve a shade of grey, set saturation to 0%.
 
-### Using The Tile Viewer Feature
+Another menu known as "advanced options" is accessible from the character creation menu. Its button is located after "skip intro". This menu uses the WASD keys to navigate and adjust options. It can only be dismissed by pressing "OK" at the bottom of the menu.
+When finished configuring your new game and character, select "OK" to start the game. If you enabled "skip intro", you will be placed immediately in your farm. Otherwise, the game will proceed to the intro cutscene.
 
-With this feature you can browse the map tile by tile without moving the player.
-Because the feature moves and snaps the mouse cursor to the tiles, it can also be used to place certain furnitures which might be difficult to place normally like a t.v., rug, calendar on the wall, etc.
-You can use the arrow keys on keyboard to use this feature and if you are using a controller you can also remap these to your controller's buttons from the `config.json`.
-While using this feature, you can also press `left control + enter` to auto move the player to the focused tile if possible, this can come in handy in places like mines.
-Look at the [keybindings](keybindings.md#tile-viewer-keys) and [configs](config.md#tile-viewer-configs) of this feature.
+## Saving Your Progress
 
-<!-- ### Planting And Harvesting -->
+To save your progress, sleep in your bed. Walk into your bed to enter it and select "go to sleep" from the new dialogue. This is usually done at the end of the day. Exiting the game without sleeping will discard that day's progress.
+If you can't enter your bed, try approaching it from a different position. The bed cannot be entered from the bottom or the top tiles since the headboard and footboard are in the way. Assuming you have not moved your bed, it is easiest to enter it from its center tile on the side of the bed.
+You can also use the `debug wh` or `debug warphome` commands which will teleport you directly onto the bed. Next, move one block off of the bed. Then move back onto it to open the sleep dialogue.
+As stated before, you may need to move in different directions to get off the bed, depending on the position and orientation of your bed.
 
-<!-- ### Buying And Selling Stuff -->
+**Important:** If you have not upgraded your house and you have not moved your bed, move to X: 8, Y: 9. This will place you directly next to the center tile of the bed's left side. The bed is 3 tiles high. To enter the bed, walk to the right. This will only work if your bed has not been moved and you have not upgraded your farmhouse. Doing either of these will change the location of your bed.
 
-### Constructing/Upgrading/Moving/Demolishing Buildings
+## Using The Tile Viewer
 
-For constructing or moving a building, we first need to mark the tile where we want the building to be constructed/moved.
-To do that, stand on that specific tile and enter the command `mark` followed by a index value which can be from 0 to 9.
-So, for example, `mark 0`. This list can only store 10 tile positions at a time and it will also be reset once the game is closed.
+The tile viewer allows you to move the tile cursor, review the map tile by tile without moving your character, move your character to the selected tile, and get information about the selected tile.
+Use the arrow keys to move the tile cursor to the desired location. The cursor automatically follows the tile cursor as the cursor moves. This allows you to interact with nearby items, such as the following: watering crops, tilling soil, placing furniture, and more.
+You can move your character to the selected tile with `primary left click` (default is )`left ctrl + enter`).
+You can get information about a tile by using `primary right click` (default is `left shift + enter`).
+This will open a dialogue which provides you with various options:
 
-Also note that the marked tile position will be the top left position of the building, so, clear the area accordingly.
-If you are constructing a building whose dimension is 4 by 5 at the tile 66x 75y, then the constructed building will cover the tiles between 66x 75y, 70x 75y, 66x 80y and 70x 80y.
+1. Mark this tile
+    - adds the selected tile to the mark index of your choice. This feature was formerly used for constructing farm buildings.
+    - Use command `marklist` in the SMAPI console to show all marked positions
+2. Add this tile to user tile data
+    - Allows you to mark a tile and assign it a category so that it appears in the object tracker
+    - You can enable additional checks, such as active quests, mod dependencies, farm type, or whether the player is a Joja member
+3. Speak detailed tile info
+    - Get more information about the selected tile
 
-After you've marked the tile, you can go to Robin's shop and select the `construct farm buildings` option.
-Now if you want to construct/upgrade/move a building, select the blueprint of that building by using the next and previous buttons. You can press `c` key to repeat the details of the blueprint.
-Then select the appropriate button for the task and then it should take you back to the farm map.
+This feature can be remapped to a controller/gamepad via the `config.json` file. More info available in [keybindings](keybindings.md#tile-viewer-keys) and [configs](config.md#tile-viewer-configs).
 
-If you want to construct/move the building, use the command `buildsel` followed by the index at which you marked the tile previously with the `mark` command (if you don't remember then you can enter the `marklist` command), for example, `buildsel 0`.
-If you want to upgrade/demolish a building, you first have to find out the index of the building you want to upgrade/demolish by entering the `buildlist` command and then again enter the `buildsel` command followed by the index of the building.
+<!--todo: Planting And Harvesting-->
 
-### Purchasing/Moving Farm Animals
+<!--todo: Buying And Selling Stuff-->
 
-The process is very similar to how we upgrade/demolish a building.
-To purchase the animal, go to Marnie's shop and select the `purchase farm animal` option and then select the animal you want to purchase.
-In case you want to move an animal to another building, interact with the animal which will open up a menu with the details about that animal, there you'll find the move option.
+## Farm Buildings
 
-Now that should've taken you back to the farm map.
-Here, you have to enter the command `buildsel` followed by the index of the building where you want to move the animal to.
-To get the index enter the `buildlist` command. And that's it, it should've moved the animal to the new building and if you were purchasing it, then it should open up a menu where you have to enter the name of the animal.
+The following guides are all related to constructing and managing buildings on your farm such as coops, silos, barns, and more. All of them are accomplished through the construction menu in Robin's shop in the mountains. This shop is labeled as "ScienceHouse" in-game. Enter Robin's shop during business hours and select "construct farm buildings" from the shop counter menu to find a list of building blueprints and construction options.
+
+- [Constructing Farm Buildings](#constructing-farm-buildings)
+- [Upgrading Farm Buildings](#upgrading-farm-buildings)
+- [Moving Farm Buildings](#moving-farm-buildings)
+- [Demolishing Farm Buildings](#demolishing-farm-buildings)
+
+### Constructing Farm Buildings
+
+To construct a building on your farm, first decide where you want to build it and ensure that there is no debris in the area. The [tile cursor](#using-the-tile-viewer) is very helpful for accomplishing this. Different buildings will occupy different amounts of space on your farm. Check Robin's shop for more info.
+Once you have decided where you want your building to be and cleared debris from the area, collect the necessary materials for construction and ensure you have enough money. Go to Robin's shop, select "construct farm buildings" from the shop counter dialogue, and use the controls in the new menu to select the desired farm building to construct. To repeat information about the currently-selected building in this menu, press `C`.
+Once you have selected the building you want to construct, click "construct". A map of your farm will appear on screen.
+Use the arrow keys to focus on the coordinate where you want to place the building. As you move the tile cursor around, the map will scroll when the cursor reaches the edge of the portion of the map that is visible on screen. This will result in the tile cursor appearing to move too far as the map scrolls beneath it.
+The map will continue scrolling until you move the tile cursor away from the edge of the screen or until the map scrolls all the way to a map edge. To scroll the map a small amount, you must move the tile cursor back and forth to "nudge" the map forward. If you think this is terrible, sighted players agree with you.
+Once you are focused on the tile you want to select, use left mouse click to place the building for construction. If the building cannot be constructed, nothing will happen. If the building can be constructed, Robin will speak to you and inform you that she will begin work the next day (unless the next day has a festival, in which case she will begin work the day after tomorrow).
+During construction, you will find Robin on your farm hard at work and you will be unable to construct additional buildings or upgrade your house. It will take several days for Robin to construct the farm building.
+Note: the tile you select will be the top-left corner of the building. For example, if you are building a silo which is 3 tiles by 3 tiles, select the tile at the very top-left of the 3x3 area you have prepared. If you select X:64, Y:21, the silo will occupy a footprint from X:64, Y:21 to X:67, Y:24.
+
+**If you cannot place your building where you want**, ensure the following are all true:
+
+1. you have enough money to construct the desired building
+2. you have enough resources in your inventory to construct the building
+3. The area you have selected is *completely clear* of **all** debris
+4. There are no other buildings or items overlapping the building you are attempting to construct
+5. You are selecting the correct tile (Remember, you are placing the building from the top-left corner) and map scrolling can move you to an undesired tile
+
+### Upgrading Farm Buildings
+
+The barn, shed, and coop farm buildings can be upgraded. Doing this involves many of the same steps as constructing a new farm building, however instead of placing a new building on your farm, you must select an existing building that can be upgraded.
+The coop and barn must both be upgraded in their own specific orders, but they have similar names: coop and barn, big coop and big barn, deluxe coop and deluxe barn. The shed only has one upgrade option, "big shed".
+As an example: to upgrade a regular coop, select "big coop" from the construction menu. To upgrade a big barn, select "deluxe barn" from the construction menu. You cannot skip upgrade stages.
+Once you enter the map interface, place the tile cursor over any portion of the building you want to upgrade and use left mouse click. If successful, Robin will tell you that she will begin work on the upgrade the next day. It will take several days to upgrade the building. Unlike constructing a new building, Robin will be inside the building while she upgrades it. Like constructing a new building, you will not be able to construct any other buildings or upgrade your house while Robin works.
+
+### Moving Farm Buildings
+
+To move a farm building, select "move building" from the construction menu. The currently-selected blueprint does not matter. Once in the map interface, move the tile cursor onto any portion of the building you want to move and use left mouse click.
+You will hear a sound once you have successfully selected a building. From this point, the directions are identical to [constructing a new farm building](#constructing-farm-buildings).
+Move the tile cursor to the new desired location. The area must be free of debris, items, and other buildings in order to move the selected building. Left mouse click to place the building down. When successful, you will hear another sound and you will be returned to the shop. You do not have to wait any time for your buildings to be moved.
+
+**Important:** Regardless of which portion of the building you select, you will place the building down from its top left corner. For example: if you select the center tile of a silo and then place it down at X:64, Y:21, the silo will occupy a footprint from X:64, Y:21 to X:67, Y:24 regardless of which part of the silo you initially selected.
+
+<!--painting farm buildings. Not yet accessible-->
+
+### Demolishing Farm Buildings
+
+To demolish a farm building, select "demolish building" from the construction menu. The currently-selected blueprint does not matter. Once in the map interface, use the tile cursor to select any portion of the building you want to demolish. There will be no confirmation dialogue, so make sure you actually want to demolish a building before selecting it. If successful, you will hear an explosion sound and be returned to the shop. The building has now been demolished.
+
+## Farm Animals
+
+The following guides provide instructions on how to purchase and move farm animals. This feature currently relies on console commands.
+
+<!--todo: update docs once accessible feature is implemented in-game-->
+
+- [Purchasing Farm Animals](#purchasing-farm-animals)
+- [Moving Farm Animals](#moving-farm-animals)
+
+### Purchasing Farm Animals
+
+To purchase animals for your farm, you must first have an appropriate farm building to house them. See [the farm buildings section](#farm-buildings) for details. Not all animals can be housed in all buildings. Chickens and ducks may only be housed in coops, cows and goats may only be housed in barns, and certain other animals require upgraded coops or barns.
+
+Go to Marnie's ranch in the forest (a.k.a AnimalShop) during business hours and select "purchase animals" from the shop counter dialogue.
+A new menu will open with a grid of options. Depending on which farm buildings you have constructed, you may see the names of various animals or a message informing you that a specific farm building is required.
+If the animal can be purchased, its name will be read along with its price, description, and the type of building it lives in. Select the animal you wish to purchase with left mouse click.
+Once the map interface opens, enter the command `buildlist` into the SMAPI console to get a list of all farm buildings. Then enter `buildsel <i>`, replacing `<i>` with the number of the building you want to place the animal in. If successful, you will be presented with a text box to name the animal. Interact with it, enter the desired name, press escape, and then select "ok" below the textbox. Marnie will deliver your animal to their new home.
+
+If you cannot purchase an animal, ensure the following are true:
+
+1. You have the correct farm building for that animal
+2. You have enough money to purchase that animal
+3. You are selecting the correct farm building
+4. The farm building you are selecting has space for that animal
+
+### Moving Farm Animals
+
+To move an animal that you own to another building, use action button on that animal to open their menu. If you have not pet your animal that day yet, you may need to press twice to do this. This menu allows you to sell your animal, rename it, and change its home building. Select "change home building". Once the map interface opens, enter the command `buildlist` to get a list of all farm buildings. Then enter `buildsel <i>`, replacing `<i>` with the number of the building you want to place the animal in. If successful, the animal will be moved to the new building and you will return to the game.
+
+If you cannot move an animal to a new building, ensure that the following are true:
+
+1. The animal can live in the building you are moving it to
+2. The building you are moving the animal to has room for the animal
+3. You are selecting the correct building
+
+<!--todo: more animal guides probably-->
 
 ## Other Pages
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -133,4 +133,4 @@ It is by default `C` but can be changed from the mod's config file.
 - [Features](features.md)
 - [Commands](commands.md)
 - [Configs](config.md)
-- [Guides](https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md)
+- [Guides](guides.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -187,4 +187,4 @@ this [issue page](https://github.com/khanshoaib3/stardew-access/issues/181).
 - [Keybindings](keybindings.md)
 - [Commands](commands.md)
 - [Configs](config.md)
-- [Guides](https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md)
+- [Guides](guides.md)

--- a/stardew-access/compiled-docs/README.html
+++ b/stardew-access/compiled-docs/README.html
@@ -15,7 +15,7 @@ It also patches the various menus and the fishing mini-game (more mini-games wil
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="guides.md">Guides</a></li>
+  <li><a href="guides.html">Guides</a></li>
 </ul>
 
 <h2 id="useful-links">Useful Links</h2>

--- a/stardew-access/compiled-docs/README.html
+++ b/stardew-access/compiled-docs/README.html
@@ -15,7 +15,7 @@ It also patches the various menus and the fishing mini-game (more mini-games wil
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md">Guides</a></li>
+  <li><a href="guides.md">Guides</a></li>
 </ul>
 
 <h2 id="useful-links">Useful Links</h2>
@@ -52,7 +52,7 @@ It also patches the various menus and the fishing mini-game (more mini-games wil
 <h2 id="translations">Translations</h2>
 
 <p>As of v1.5.0, the mod has been fully internationalised.
-Follow <a href="https://github.com/khanshoaib3/stardew-access/issues/182">this</a> issue page to track the progress of
+Follow <a href="https://github.com/khanshoaib3/stardew-access/issues/182">this issue page</a> to track the progress of
 translations currently in the works and/or if you want to provide translation for your language.</p>
 
 <h2 id="contact-us">Contact Us</h2>

--- a/stardew-access/compiled-docs/commands.html
+++ b/stardew-access/compiled-docs/commands.html
@@ -230,5 +230,5 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
   <li><a href="features.html">Features</a></li>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md">Guides</a></li>
+  <li><a href="guides.md">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/commands.html
+++ b/stardew-access/compiled-docs/commands.html
@@ -230,5 +230,5 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
   <li><a href="features.html">Features</a></li>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="guides.md">Guides</a></li>
+  <li><a href="guides.html">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/config.html
+++ b/stardew-access/compiled-docs/config.html
@@ -690,5 +690,5 @@ visit <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#B
   <li><a href="features.html">Features</a></li>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
-  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md">Guides</a></li>
+  <li><a href="guides.md">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/config.html
+++ b/stardew-access/compiled-docs/config.html
@@ -690,5 +690,5 @@ visit <a href="https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#B
   <li><a href="features.html">Features</a></li>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
-  <li><a href="guides.md">Guides</a></li>
+  <li><a href="guides.html">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/features.html
+++ b/stardew-access/compiled-docs/features.html
@@ -111,5 +111,5 @@ The game not supporting stereo sound makes this feature somewhat confusing.</p>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md">Guides</a></li>
+  <li><a href="guides.md">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/features.html
+++ b/stardew-access/compiled-docs/features.html
@@ -111,5 +111,5 @@ The game not supporting stereo sound makes this feature somewhat confusing.</p>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="guides.md">Guides</a></li>
+  <li><a href="guides.html">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/guides.html
+++ b/stardew-access/compiled-docs/guides.html
@@ -1,0 +1,239 @@
+<h1 id="guides">Guides</h1>
+
+<p>This page provides guides for playing Stardew Valley with Stardew Access enabled. While Stardew Access attempts to provide its players feature parity with the base game, some activities must be performed differently and/or may not be obvious to new players. This page assumes that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the <a href="setup.html">setup page</a>.
+Information about the controls for Stardew Access and Stardew Valley can be found in <a href="keybindings.html">Keybindings</a>.</p>
+
+<h2 id="table-of-contents">Table Of Contents</h2>
+
+<ul>
+  <li><a href="#key-terms-and-controls">Key Terms and Controls</a></li>
+  <li><a href="#creating-a-new-game">Creating a New Game</a></li>
+  <li><a href="#saving-your-progress">Saving Your Progress</a></li>
+  <li><a href="#using-the-tile-viewer">Using The Tile Viewer</a></li>
+  <li><a href="#farm-buildings">Farm Buildings</a>
+    <ul>
+      <li><a href="#constructing-farm-buildings">Constructing Farm Buildings</a></li>
+      <li><a href="#upgrading-farm-buildings">Upgrading Farm Buildings</a></li>
+      <li><a href="#moving-farm-buildings">Moving Farm Buildings</a></li>
+      <li><a href="#demolishing-farm-buildings">Demolishing Farm Buildings</a></li>
+    </ul>
+  </li>
+  <li><a href="#farm-animals">Farm Animals</a>
+    <ul>
+      <li><a href="#purchasing-farm-animals">Purchasing Farm Animals</a></li>
+      <li><a href="#moving-farm-animals">Moving Farm Animals</a></li>
+    </ul>
+  </li>
+  <li><a href="#other-pages">Other Pages</a></li>
+</ul>
+
+<h2 id="key-terms-and-controls">Key Terms and Controls</h2>
+
+<ul>
+  <li>Controls
+    <ul>
+      <li>Primary left click, <code>left ctrl + Enter</code> or secondary left click, <code>[</code> (left square bracket): Use one of these to emulate a left mouse-click</li>
+      <li>primary right click, <code>left shift + enter</code> or secondary right click, <code>]</code> (right square bracket): emulate a right mouse click</li>
+      <li>WASD: the four navigation keys used to navigate most of the game</li>
+      <li>arrow keys: the four keys used to navigate certain menus</li>
+      <li><a href="keybindings.html">full list of keybindings</a> .</li>
+    </ul>
+  </li>
+  <li>Terms
+    <ul>
+      <li>title screen: the first screen you encounter when launching the game.</li>
+      <li>main menu: The menu immediately after the title screen which lets you create and load games.</li>
+      <li>character creation menu: a menu that allows you to customize options for a new game</li>
+      <li>construction menu: the menu for managing farm buildings accessed in Robin’s shop</li>
+      <li>dialogue: a menu pop-up which may present a short list of options or a character’s speech</li>
+      <li>shop counter dialogue: a dialogue which appears at the shop counters of businesses which offer more services than just item purchases</li>
+      <li>shop counter menu: a menu accessed through the shop counters of businesses which allow you to purchase items</li>
+      <li>grid: the portion of the map which is used for placing items and buildings</li>
+      <li>tile: a square-shaped portion of the grid where items may be placed</li>
+      <li>cursor: the pointer that sighted players use to select items and options</li>
+      <li>tile cursor: a feature of the tile viewer which allows Stardew Access Players to move the cursor around on the map</li>
+      <li>map interface: a screen which appears when purchasing farm animals or managing farm buildings</li>
+    </ul>
+  </li>
+</ul>
+
+<h2 id="creating-a-new-game">Creating a New Game</h2>
+
+<p>Once you are on the  main menu, use the WASD keys to focus on different options. Select the “new game” button to the left of “load game” to open the new game menu (also known as the character customization menu).
+In the new game menu, use the right and left arrow keys to move to the next and previous elements, respectively.
+To use a text box, interact with it using left mouse click, type the desired text, and finally press <code>Escape</code> to stop interacting with it while focused on the desired text box.
+To modify the value of a slider, use <code>up arrow</code> and <code>down arrow</code> or <code>pageUp</code> and <code>pageDown</code> while focused on the desired slider.
+Some controls allow you to cycle back and forth through a set of options. These controls appear in pairs, one immediately after the other and will include “previous” and “next” in their respective names. Focusing on them will announce the currently selected option. Pressing either will announce the newly-selected option. To hear the currently-selected option again, move focus off of the controls and then move focus onto them again.</p>
+
+<p>Character creation controls are shown by default. To toggle their visibility, Press <code>Left Control + Space</code>. This is where you will find sliders for options such as /hair color and eye color. Color sliders appear in sets of 3 and adjust hue, saturation, and value (brightness). They announce their current value in the same fashion as the “next” and “previous” pairs. Their individual values range from 0% to 99%. Below is an explanation of what each slider does. Note that the game may report different names for each unique color that results from a particular slider configuration.</p>
+
+<ul>
+  <li>Hue spans through the color spectrum from red at the minimum, through the rainbow, and back to red at the maximum.
+    <ul>
+      <li>At 99% saturation and 99% value, Hue spans from 0% to 99% as follows: red, orange, yellow, green, blue, indigo, violet, magenta, red</li>
+    </ul>
+  </li>
+  <li>Saturation spans from none at the minimum to full saturation of the selected hue at maximum.
+    <ul>
+      <li>At 0% hue and 99% value, 0% saturation is white and 99% saturation is bright red.</li>
+    </ul>
+  </li>
+  <li>Value, also known as brightness, adjusts the brightness of the selected hue and saturation from black to full brightness.
+    <ul>
+      <li>at 0% hue and 99% saturation, 0% value is black and 99% value is bright red. To achieve a shade of grey, set saturation to 0%.</li>
+    </ul>
+  </li>
+</ul>
+
+<p>Another menu known as “advanced options” is accessible from the character creation menu. Its button is located after “skip intro”. This menu uses the WASD keys to navigate and adjust options. It can only be dismissed by pressing “OK” at the bottom of the menu.
+When finished configuring your new game and character, select “OK” to start the game. If you enabled “skip intro”, you will be placed immediately in your farm. Otherwise, the game will proceed to the intro cutscene.</p>
+
+<h2 id="saving-your-progress">Saving Your Progress</h2>
+
+<p>To save your progress, sleep in your bed. Walk into your bed to enter it and select “go to sleep” from the new dialogue. This is usually done at the end of the day. Exiting the game without sleeping will discard that day’s progress.
+If you can’t enter your bed, try approaching it from a different position. The bed cannot be entered from the bottom or the top tiles since the headboard and footboard are in the way. Assuming you have not moved your bed, it is easiest to enter it from its center tile on the side of the bed.
+You can also use the <code>debug wh</code> or <code>debug warphome</code> commands which will teleport you directly onto the bed. Next, move one block off of the bed. Then move back onto it to open the sleep dialogue.
+As stated before, you may need to move in different directions to get off the bed, depending on the position and orientation of your bed.</p>
+
+<p><strong>Important:</strong> If you have not upgraded your house and you have not moved your bed, move to X: 8, Y: 9. This will place you directly next to the center tile of the bed’s left side. The bed is 3 tiles high. To enter the bed, walk to the right. This will only work if your bed has not been moved and you have not upgraded your farmhouse. Doing either of these will change the location of your bed.</p>
+
+<h2 id="using-the-tile-viewer">Using The Tile Viewer</h2>
+
+<p>The tile viewer allows you to move the tile cursor, review the map tile by tile without moving your character, move your character to the selected tile, and get information about the selected tile.
+Use the arrow keys to move the tile cursor to the desired location. The cursor automatically follows the tile cursor as the cursor moves. This allows you to interact with nearby items, such as the following: watering crops, tilling soil, placing furniture, and more.
+You can move your character to the selected tile with <code>primary left click</code> (default is )<code>left ctrl + enter</code>).
+You can get information about a tile by using <code>primary right click</code> (default is <code>left shift + enter</code>).
+This will open a dialogue which provides you with various options:</p>
+
+<ol>
+  <li>Mark this tile
+    <ul>
+      <li>adds the selected tile to the mark index of your choice. This feature was formerly used for constructing farm buildings.</li>
+      <li>Use command <code>marklist</code> in the SMAPI console to show all marked positions</li>
+    </ul>
+  </li>
+  <li>Add this tile to user tile data
+    <ul>
+      <li>Allows you to mark a tile and assign it a category so that it appears in the object tracker</li>
+      <li>You can enable additional checks, such as active quests, mod dependencies, farm type, or whether the player is a Joja member</li>
+    </ul>
+  </li>
+  <li>Speak detailed tile info
+    <ul>
+      <li>Get more information about the selected tile</li>
+    </ul>
+  </li>
+</ol>
+
+<p>This feature can be remapped to a controller/gamepad via the <code>config.json</code> file. More info available in <a href="keybindings.html#tile-viewer-keys">keybindings</a> and <a href="config.html#tile-viewer-configs">configs</a>.</p>
+
+<!--todo: Planting And Harvesting-->
+
+<!--todo: Buying And Selling Stuff-->
+
+<h2 id="farm-buildings">Farm Buildings</h2>
+
+<p>The following guides are all related to constructing and managing buildings on your farm such as coops, silos, barns, and more. All of them are accomplished through the construction menu in Robin’s shop in the mountains. This shop is labeled as “ScienceHouse” in-game. Enter Robin’s shop during business hours and select “construct farm buildings” from the shop counter menu to find a list of building blueprints and construction options.</p>
+
+<ul>
+  <li><a href="#constructing-farm-buildings">Constructing Farm Buildings</a></li>
+  <li><a href="#upgrading-farm-buildings">Upgrading Farm Buildings</a></li>
+  <li><a href="#moving-farm-buildings">Moving Farm Buildings</a></li>
+  <li><a href="#demolishing-farm-buildings">Demolishing Farm Buildings</a></li>
+</ul>
+
+<h3 id="constructing-farm-buildings">Constructing Farm Buildings</h3>
+
+<p>To construct a building on your farm, first decide where you want to build it and ensure that there is no debris in the area. The <a href="#using-the-tile-viewer">tile cursor</a> is very helpful for accomplishing this. Different buildings will occupy different amounts of space on your farm. Check Robin’s shop for more info.
+Once you have decided where you want your building to be and cleared debris from the area, collect the necessary materials for construction and ensure you have enough money. Go to Robin’s shop, select “construct farm buildings” from the shop counter dialogue, and use the controls in the new menu to select the desired farm building to construct. To repeat information about the currently-selected building in this menu, press <code>C</code>.
+Once you have selected the building you want to construct, click “construct”. A map of your farm will appear on screen.
+Use the arrow keys to focus on the coordinate where you want to place the building. As you move the tile cursor around, the map will scroll when the cursor reaches the edge of the portion of the map that is visible on screen. This will result in the tile cursor appearing to move too far as the map scrolls beneath it.
+The map will continue scrolling until you move the tile cursor away from the edge of the screen or until the map scrolls all the way to a map edge. To scroll the map a small amount, you must move the tile cursor back and forth to “nudge” the map forward. If you think this is terrible, sighted players agree with you.
+Once you are focused on the tile you want to select, use left mouse click to place the building for construction. If the building cannot be constructed, nothing will happen. If the building can be constructed, Robin will speak to you and inform you that she will begin work the next day (unless the next day has a festival, in which case she will begin work the day after tomorrow).
+During construction, you will find Robin on your farm hard at work and you will be unable to construct additional buildings or upgrade your house. It will take several days for Robin to construct the farm building.
+Note: the tile you select will be the top-left corner of the building. For example, if you are building a silo which is 3 tiles by 3 tiles, select the tile at the very top-left of the 3x3 area you have prepared. If you select X:64, Y:21, the silo will occupy a footprint from X:64, Y:21 to X:67, Y:24.</p>
+
+<p><strong>If you cannot place your building where you want</strong>, ensure the following are all true:</p>
+
+<ol>
+  <li>you have enough money to construct the desired building</li>
+  <li>you have enough resources in your inventory to construct the building</li>
+  <li>The area you have selected is <em>completely clear</em> of <strong>all</strong> debris</li>
+  <li>There are no other buildings or items overlapping the building you are attempting to construct</li>
+  <li>You are selecting the correct tile (Remember, you are placing the building from the top-left corner) and map scrolling can move you to an undesired tile</li>
+</ol>
+
+<h3 id="upgrading-farm-buildings">Upgrading Farm Buildings</h3>
+
+<p>The barn, shed, and coop farm buildings can be upgraded. Doing this involves many of the same steps as constructing a new farm building, however instead of placing a new building on your farm, you must select an existing building that can be upgraded.
+The coop and barn must both be upgraded in their own specific orders, but they have similar names: coop and barn, big coop and big barn, deluxe coop and deluxe barn. The shed only has one upgrade option, “big shed”.
+As an example: to upgrade a regular coop, select “big coop” from the construction menu. To upgrade a big barn, select “deluxe barn” from the construction menu. You cannot skip upgrade stages.
+Once you enter the map interface, place the tile cursor over any portion of the building you want to upgrade and use left mouse click. If successful, Robin will tell you that she will begin work on the upgrade the next day. It will take several days to upgrade the building. Unlike constructing a new building, Robin will be inside the building while she upgrades it. Like constructing a new building, you will not be able to construct any other buildings or upgrade your house while Robin works.</p>
+
+<h3 id="moving-farm-buildings">Moving Farm Buildings</h3>
+
+<p>To move a farm building, select “move building” from the construction menu. The currently-selected blueprint does not matter. Once in the map interface, move the tile cursor onto any portion of the building you want to move and use left mouse click.
+You will hear a sound once you have successfully selected a building. From this point, the directions are identical to <a href="#constructing-farm-buildings">constructing a new farm building</a>.
+Move the tile cursor to the new desired location. The area must be free of debris, items, and other buildings in order to move the selected building. Left mouse click to place the building down. When successful, you will hear another sound and you will be returned to the shop. You do not have to wait any time for your buildings to be moved.</p>
+
+<p><strong>Important:</strong> Regardless of which portion of the building you select, you will place the building down from its top left corner. For example: if you select the center tile of a silo and then place it down at X:64, Y:21, the silo will occupy a footprint from X:64, Y:21 to X:67, Y:24 regardless of which part of the silo you initially selected.</p>
+
+<!--painting farm buildings. Not yet accessible-->
+
+<h3 id="demolishing-farm-buildings">Demolishing Farm Buildings</h3>
+
+<p>To demolish a farm building, select “demolish building” from the construction menu. The currently-selected blueprint does not matter. Once in the map interface, use the tile cursor to select any portion of the building you want to demolish. There will be no confirmation dialogue, so make sure you actually want to demolish a building before selecting it. If successful, you will hear an explosion sound and be returned to the shop. The building has now been demolished.</p>
+
+<h2 id="farm-animals">Farm Animals</h2>
+
+<p>The following guides provide instructions on how to purchase and move farm animals. This feature currently relies on console commands.</p>
+
+<!--todo: update docs once accessible feature is implemented in-game-->
+
+<ul>
+  <li><a href="#purchasing-farm-animals">Purchasing Farm Animals</a></li>
+  <li><a href="#moving-farm-animals">Moving Farm Animals</a></li>
+</ul>
+
+<h3 id="purchasing-farm-animals">Purchasing Farm Animals</h3>
+
+<p>To purchase animals for your farm, you must first have an appropriate farm building to house them. See <a href="#farm-buildings">the farm buildings section</a> for details. Not all animals can be housed in all buildings. Chickens and ducks may only be housed in coops, cows and goats may only be housed in barns, and certain other animals require upgraded coops or barns.</p>
+
+<p>Go to Marnie’s ranch in the forest (a.k.a AnimalShop) during business hours and select “purchase animals” from the shop counter dialogue.
+A new menu will open with a grid of options. Depending on which farm buildings you have constructed, you may see the names of various animals or a message informing you that a specific farm building is required.
+If the animal can be purchased, its name will be read along with its price, description, and the type of building it lives in. Select the animal you wish to purchase with left mouse click.
+Once the map interface opens, enter the command <code>buildlist</code> into the SMAPI console to get a list of all farm buildings. Then enter <code>buildsel &lt;i&gt;</code>, replacing <code>&lt;i&gt;</code> with the number of the building you want to place the animal in. If successful, you will be presented with a text box to name the animal. Interact with it, enter the desired name, press escape, and then select “ok” below the textbox. Marnie will deliver your animal to their new home.</p>
+
+<p>If you cannot purchase an animal, ensure the following are true:</p>
+
+<ol>
+  <li>You have the correct farm building for that animal</li>
+  <li>You have enough money to purchase that animal</li>
+  <li>You are selecting the correct farm building</li>
+  <li>The farm building you are selecting has space for that animal</li>
+</ol>
+
+<h3 id="moving-farm-animals">Moving Farm Animals</h3>
+
+<p>To move an animal that you own to another building, use action button on that animal to open their menu. If you have not pet your animal that day yet, you may need to press twice to do this. This menu allows you to sell your animal, rename it, and change its home building. Select “change home building”. Once the map interface opens, enter the command <code>buildlist</code> to get a list of all farm buildings. Then enter <code>buildsel &lt;i&gt;</code>, replacing <code>&lt;i&gt;</code> with the number of the building you want to place the animal in. If successful, the animal will be moved to the new building and you will return to the game.</p>
+
+<p>If you cannot move an animal to a new building, ensure that the following are true:</p>
+
+<ol>
+  <li>The animal can live in the building you are moving it to</li>
+  <li>The building you are moving the animal to has room for the animal</li>
+  <li>You are selecting the correct building</li>
+</ol>
+
+<!--todo: more animal guides probably-->
+
+<h2 id="other-pages">Other Pages</h2>
+
+<ul>
+  <li><a href="README.html">Readme</a></li>
+  <li><a href="setup.html">Setup</a></li>
+  <li><a href="features.html">Features</a></li>
+  <li><a href="keybindings.html">Keybindings</a></li>
+  <li><a href="commands.html">Commands</a></li>
+  <li><a href="config.html">Configs</a></li>
+</ul>

--- a/stardew-access/compiled-docs/guides.html
+++ b/stardew-access/compiled-docs/guides.html
@@ -10,6 +10,13 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
   <li><a href="#creating-a-new-game">Creating a New Game</a></li>
   <li><a href="#saving-your-progress">Saving Your Progress</a></li>
   <li><a href="#using-the-tile-viewer">Using The Tile Viewer</a></li>
+  <li><a href="#farming">Farming</a>
+    <ul>
+      <li><a href="#planting-crops">Planting Crops</a></li>
+      <li><a href="#growing-crops">Growing Crops</a></li>
+      <li><a href="#harvesting-crops">Harvesting Crops</a></li>
+    </ul>
+  </li>
   <li><a href="#farm-buildings">Farm Buildings</a>
     <ul>
       <li><a href="#constructing-farm-buildings">Constructing Farm Buildings</a></li>
@@ -65,7 +72,7 @@ To use a text box, interact with it using left mouse click, type the desired tex
 To modify the value of a slider, use <code>up arrow</code> and <code>down arrow</code> or <code>pageUp</code> and <code>pageDown</code> while focused on the desired slider.
 Some controls allow you to cycle back and forth through a set of options. These controls appear in pairs, one immediately after the other and will include “previous” and “next” in their respective names. Focusing on them will announce the currently selected option. Pressing either will announce the newly-selected option. To hear the currently-selected option again, move focus off of the controls and then move focus onto them again.</p>
 
-<p>Character creation controls are shown by default. To toggle their visibility, Press <code>Left Control + Space</code>. This is where you will find sliders for options such as /hair color and eye color. Color sliders appear in sets of 3 and adjust hue, saturation, and value (brightness). They announce their current value in the same fashion as the “next” and “previous” pairs. Their individual values range from 0% to 99%. Below is an explanation of what each slider does. Note that the game may report different names for each unique color that results from a particular slider configuration.</p>
+<p>Character creation controls are shown by default. To toggle their visibility, Press <code>Left Control + Space</code>. This is where you will find sliders for options such as hair color and eye color. Color sliders appear in sets of 3 and adjust hue, saturation, and value (brightness). They announce their current value in the same fashion as the “next” and “previous” pairs. Their individual values range from 0% to 99%. Below is an explanation of what each slider does. Note that the game may report different names for each unique color that results from a particular slider configuration.</p>
 
 <ul>
   <li>Hue spans through the color spectrum from red at the minimum, through the rainbow, and back to red at the maximum.
@@ -127,9 +134,39 @@ This will open a dialogue which provides you with various options:</p>
 
 <p>This feature can be remapped to a controller/gamepad via the <code>config.json</code> file. More info available in <a href="keybindings.html#tile-viewer-keys">keybindings</a> and <a href="config.html#tile-viewer-configs">configs</a>.</p>
 
-<!--todo: Planting And Harvesting-->
-
 <!--todo: Buying And Selling Stuff-->
+
+<h2 id="farming">Farming</h2>
+
+<p>Farming, including planting and harvesting crops, is the primary way to make money in Stardew Valley, especially in the early-game. The following guides will cover how to farm.</p>
+
+<ul>
+  <li><a href="#planting-crops">Planting Crops</a></li>
+  <li><a href="#growing-crops">Growing Crops</a></li>
+  <li><a href="#harvesting-crops">Harvesting Crops</a></li>
+</ul>
+
+<h3 id="planting-crops">Planting Crops</h3>
+
+<p>Once you have purchased seeds from Pierre’s general store in the town (a.k.a) SeedShop) or otherwise obtained seeds, go to your farm and use your tools to clear a plot of land to plant them. Make sure to clear grass as well.
+Your scythe does not consume any of your energy. Once you have cleared sufficient land to plant your crops, use your hoe to till the soil.
+Next, use your watering can to water the soil and add any <a href="https://stardewvalleywiki.com/Fertilizer">fertilizer</a> if desired to the soil.
+finally, place your crops in the soil. You may plant your crops before watering, but fertilizers <strong>must</strong> be placed before the crop is placed.
+Tilling individual tiles can be very tedious, so be sure to check Clint’s shop in the town (a.k.a Blacksmith) for tool upgrades. Once you upgrade your hoe, you can hold down <code>tool button</code> and hoe several tiles at a time.</p>
+
+<h3 id="growing-crops">Growing crops</h3>
+
+<p>Different crops will take different amounts of time to grow. Most crops will only grow during one season, however they will grow during any season in the greenhouse. Growing season and growing time are listed in Pierre’s shop as well as on the item’s tooltip in your inventory.
+Each season is 28 days long, and it’s important to ensure your crop has enough time to grow. If your crop has not been harvested before the start of the next season, it will die unless it also grows in the new season. Most crops only grow in one season. It’s important to water your crop daily. Unwatered crops will not die, but they will not grow that day.
+Each day has a chance of rain. If it rains, there is no need to water your crops as the rain will take care of it. Crops grown indoors or in the greenhouse must be watered regardless of rain. Check the TV in your farmhouse for next day’s forecast.
+You can walk over most crops safely with the exception of crops that grow on a trellis. You cannot pass through trellis crops at all, so make sure you leave enough room to reach them.
+Some crops, such as green beans, hot peppers, and blueberries, will produce multiple harvests per crop. Once they mature, you can pick the first harvest and continue watering the crops daily as normal and producing more harvests until the end of the season.
+Lastly, you may craft <a href="https://stardewvalleywiki.com/Sprinkler">sprinklers</a> in order to keep crops watered. There are several tiers of sprinklers which keep progressively more tiles watered.</p>
+
+<h3 id="harvesting-crops">Harvesting Crops</h3>
+
+<p>To harvest a mature crop, walk up to the crop and press <code>action button</code> to harvest it. The tile will be emptied and another crop may be placed. If the crop produces multiple harvests, the crop will remain on the tile and you can continue to water it as normal.
+Be careful that you do not use your pickaxe on crops as doing so will destroy them, undoing all your hard work.</p>
 
 <h2 id="farm-buildings">Farm Buildings</h2>
 

--- a/stardew-access/compiled-docs/guides.html
+++ b/stardew-access/compiled-docs/guides.html
@@ -10,6 +10,16 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
   <li><a href="#creating-a-new-game">Creating a New Game</a></li>
   <li><a href="#saving-your-progress">Saving Your Progress</a></li>
   <li><a href="#using-the-tile-viewer">Using The Tile Viewer</a></li>
+  <li><a href="#using-the-object-tracker">Using The Object Tracker</a>
+    <ul>
+      <li><a href="#object-tracker">Object Tracker</a></li>
+      <li><a href="#object-tracker-favorites">Object Tracker Favorites</a>
+        <ul>
+          <li><a href="#tracking-coordinates-with-favorites">Tracking Coordinates With Favorites</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
   <li><a href="#buying-and-selling">Buying and Selling</a></li>
   <li><a href="#farming">Farming</a>
     <ul>
@@ -134,6 +144,43 @@ This will open a dialogue which provides you with various options:</p>
 </ol>
 
 <p>This feature can be remapped to a controller/gamepad via the <code>config.json</code> file. More info available in <a href="keybindings.html#tile-viewer-keys">keybindings</a> and <a href="config.html#tile-viewer-configs">configs</a>.</p>
+
+<h2 id="using-the-object-tracker">Using The Object Tracker</h2>
+
+<p>The object tracker is an extremely helpful feature of Stardew Access. It lets you browse all of the items, NPCs, interactable items, and other points of interest on the current map. For a full list of keys and config options, check out the relevant sections in <a href="keybindings.html#object-tracker-keys">keybinds</a> and <a href="config.html#object-tracker-configs">configs</a>.</p>
+
+<ul>
+  <li><a href="#object-tracker">Object Tracker</a></li>
+  <li><a href="#object-tracker-favorites">Object Tracker Favorites</a>
+    <ul>
+      <li><a href="#tracking-coordinates-with-favorites">Tracking Coordinates With Favorites</a></li>
+    </ul>
+  </li>
+</ul>
+
+<h3 id="object-tracker">Object Tracker</h3>
+
+<p>The object tracker does two things: it lists all available objects in their respective categories, and it allows you to get their position and travel to them.
+Categories can be browsed with <code>left ctrl +pageUp</code> and <code>left ctrl + pageDown</code>. They are listed in alphabetical order, so “doors” will always come before “mine items” which will always come before “pending” which will always come before “resources” and so on.
+Not all categories will show up in all locations. The categories will only be visible if there is an object that fits that category on the current map. If you are in the town, the chances of seeing the “mine items” category will be very, very, very low.</p>
+
+<p>To browse objects within a category, use <code>pageUp</code> and <code>pageDown</code>. objects will appear within each category in the order of their proximity to you.
+IF you wish for them to show in alphabetical order, press <code>~ (tilde)</code> to toggle between proximity and alphabetical order. Note that each time the list refreshes, the order of objects will change if proximity is enabled, but categories will not change their order. If a category is visible but all items that pertain to it are removed from the map, that category will disappear once the object list refreshes. Your focus will be moved to a visible category.</p>
+
+<p>To get info on where an object is, use <code>home</code> or <code>end</code>. <code>home</code> will provide both relative directions (north 5) and absolute coordinates of the player and the object. <code>End</code> will only provide absolute coordinates. Pressing either of these keys will refresh the objects list.</p>
+
+<h3 id="object-tracker-favorites">Object Tracker Favorites</h3>
+
+<p>You can set and manage favorite objects on a per-map basis. This portion of the object tracker uses the <code>left alt</code> and <code>right alt</code> keys interchangeably, so this guide will refer to them collectively as <code>alt</code>.</p>
+
+<p>Each map has a set of favorites which can be set by holding <code>alt</code> and double-tapping a number on the number row. Be sure to focus your object tracker on the object which you want to set as the favorite first. Use the numbers on the number row, 1 through 0 to access 10 favorites at a time.
+Once a favorite is set, double-tap that number while holding <code>alt</code> to travel to that object. To hear the object location, single-tap the respective number while holding <code>alt</code>. To erase a favorite object, triple-tap its respective number while holding <code>alt</code>.</p>
+
+<p>To access more than 10 favorite objects, hold <code>alt</code> and press <code>+ (plus)</code> or <code>- (minus)</code> to browse through favorite stacks. Each map can have up to several hundred stacks, giving you access to many thousands of favorites per map.</p>
+
+<h4 id="tracking-coordinates-with-favorites">Tracking coordinates With Favorites</h4>
+
+<p>To track a specific tile coordinate, press <code>tab + ~</code> to toggle saving coordinates. When the feature is enabled, hold <code>alt</code> and double-tap the desired number on an empty favorite to save the coordinate. Don’t worry about what object the object tracker is focused on. To stop saving coordinates and return to normal functionality, disable saving coordinates with the same keystroke.</p>
 
 <h2 id="buying-and-selling">Buying and Selling</h2>
 

--- a/stardew-access/compiled-docs/guides.html
+++ b/stardew-access/compiled-docs/guides.html
@@ -10,6 +10,7 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
   <li><a href="#creating-a-new-game">Creating a New Game</a></li>
   <li><a href="#saving-your-progress">Saving Your Progress</a></li>
   <li><a href="#using-the-tile-viewer">Using The Tile Viewer</a></li>
+  <li><a href="#buying-and-selling">Buying and Selling</a></li>
   <li><a href="#farming">Farming</a>
     <ul>
       <li><a href="#planting-crops">Planting Crops</a></li>
@@ -134,7 +135,30 @@ This will open a dialogue which provides you with various options:</p>
 
 <p>This feature can be remapped to a controller/gamepad via the <code>config.json</code> file. More info available in <a href="keybindings.html#tile-viewer-keys">keybindings</a> and <a href="config.html#tile-viewer-configs">configs</a>.</p>
 
-<!--todo: Buying And Selling Stuff-->
+<h2 id="buying-and-selling">Buying and Selling</h2>
+
+<p>Buying and selling is usually accomplished through shops which are scattered throughout the valley and run by various residents of the town. They all offer different products, services, and have slightly different interfaces but all involve very similar steps. Selling your crops, fish, artisan goods, etc. can either be done at a shop or by putting the items into the shipping bin on your farm.</p>
+
+<p>This guide will use Robin’s shop as an example since Robin offers both products and services.</p>
+
+<p>To buy items:</p>
+
+<ol>
+  <li>Enter the shop during business hours (these will vary from shop to shop. Pierre’s is closed on Wednesdays) and approach the shop counter.</li>
+  <li>Interact with the shop counter to open the shop dialogue.</li>
+  <li>You can choose various options from the shop dialogue such as constructing farm buildings, upgrading your house, purchasing items, or leaving. Some shops May not offer options and only sell items. In that case, you will be placed immediately in the shop menu.</li>
+  <li>Assuming you selected “shop” or entered a shop that only sells items, you will be placed in the shop menu which presents a list of items that are sold.</li>
+  <li>To buy an item, select the desired item and use left mouse click. You can purchase 5 of an item by holding shift and using left mouse click.</li>
+</ol>
+
+<p>To sell items:</p>
+
+<ol>
+  <li>follow the first 4 steps in the previous list.</li>
+  <li>Move to your inventory items or press <code>I</code></li>
+  <li>Find the item you want to sell in your inventory. Only certain items may be sold at certain shops.</li>
+  <li>Use <code>left mouse click</code> on the item to sell the entire stack. Use ` shift + left mouse click` to sell half the stack.</li>
+</ol>
 
 <h2 id="farming">Farming</h2>
 

--- a/stardew-access/compiled-docs/guides.html
+++ b/stardew-access/compiled-docs/guides.html
@@ -3,6 +3,17 @@
 <p>This page provides guides for playing Stardew Valley with Stardew Access enabled. While Stardew Access attempts to provide its players feature parity with the base game, some activities must be performed differently and/or may not be obvious to new players. This page assumes that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the <a href="setup.html">setup page</a>.
 Information about the controls for Stardew Access and Stardew Valley can be found in <a href="keybindings.html">Keybindings</a>.</p>
 
+<h2 id="guide-version">Guide Version</h2>
+
+<p><strong>This guide file is up to date with Stardew Access <a href="https://github.com/khanshoaib3/stardew-access/releases/tag/v1.5.1">Release v1.5.1</a>.</strong></p>
+
+<p>To get the most current documentation, check the following links:</p>
+
+<ul>
+  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs">Stable Release Documentation</a></li>
+  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/development/docs#introduction">Beta Release Documentation</a></li>
+</ul>
+
 <h2 id="table-of-contents">Table Of Contents</h2>
 
 <ul>
@@ -334,6 +345,8 @@ Once the map interface opens, enter the command <code>buildlist</code> into the 
 </ol>
 
 <!--todo: more animal guides probably-->
+
+<!--todo: mining guide-->
 
 <h2 id="other-pages">Other Pages</h2>
 

--- a/stardew-access/compiled-docs/keybindings.html
+++ b/stardew-access/compiled-docs/keybindings.html
@@ -385,5 +385,5 @@ It is by default <code>C</code> but can be changed from the mod’s config file.
   <li><a href="features.html">Features</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="guides.md">Guides</a></li>
+  <li><a href="guides.html">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/keybindings.html
+++ b/stardew-access/compiled-docs/keybindings.html
@@ -385,5 +385,5 @@ It is by default <code>C</code> but can be changed from the mod’s config file.
   <li><a href="features.html">Features</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md">Guides</a></li>
+  <li><a href="guides.md">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/setup.html
+++ b/stardew-access/compiled-docs/setup.html
@@ -246,5 +246,5 @@ furniture. We highly recommend installing.</li>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="guides.md">Guides</a></li>
+  <li><a href="guides.html">Guides</a></li>
 </ul>

--- a/stardew-access/compiled-docs/setup.html
+++ b/stardew-access/compiled-docs/setup.html
@@ -246,5 +246,5 @@ furniture. We highly recommend installing.</li>
   <li><a href="keybindings.html">Keybindings</a></li>
   <li><a href="commands.html">Commands</a></li>
   <li><a href="config.html">Configs</a></li>
-  <li><a href="https://github.com/khanshoaib3/stardew-access/tree/master/docs/guides.md">Guides</a></li>
+  <li><a href="guides.md">Guides</a></li>
 </ul>


### PR DESCRIPTION
I have completely reworked the guides page and added additional guides in order to bring it up to speed with SVA 1.5+ and to improve the guides. This includes updated farm building construction and tips for using the map interface when constructing a building. The guides page is now also available in the compiled docs and relevant links have been updated in the other docs pages to point to the updated guides page. Future docs compilations with kramdown will now include the guides page.