### PR TITLE
add config toggle "Use24HourFormat" to switch to the 24-hoursformat

### DIFF
--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -506,6 +506,11 @@ internal class ModConfig
     /// </summary>
     public int FixFishingMotionType { get; set; } = 999;
 
+    /// <summary>
+    /// if true, the <see cref="stardew_access.Utils.CurrentPlayer.TimeOfDay"/> will return the time in the 24-hourformat.
+    /// </summary>
+    public bool Use24HourFormat { get; set; } = false;
+
     // TODO Add the exclusion and focus list too
     // public String ExclusionList { get; set; } = "test";
 }

--- a/stardew-access/Utils/CurrentPlayer.cs
+++ b/stardew-access/Utils/CurrentPlayer.cs
@@ -105,7 +105,7 @@ namespace stardew_access.Utils
         }
 
         /// <summary>
-        /// Returns the time in the 12 hours format
+        /// Returns the time in the 12 or 24 hours format
         /// </summary>
         public static string TimeOfDay
         {
@@ -115,11 +115,23 @@ namespace stardew_access.Utils
 
                 int minutes = timeOfDay % 100;
                 int hours = timeOfDay / 100;
-                string amOrpm = hours / 12 == 1 ? "PM" : "AM";
-                hours %= 12;
-                if (hours == 0) hours = 12;
-                return $"{hours}:{minutes:00} {amOrpm}";
-            }
+
+                if (MainClass.Config.Use24HourFormat is false)
+                {
+                    string amOrpm = hours / 12 == 1 ? "PM" : "AM";
+                    hours %= 12;
+                    if (hours == 0) hours = 12;
+                    return $"{hours}:{minutes:00} {amOrpm}";
+                } 
+                else
+                {
+                    
+                    // fix for ingame 26 hoursformat
+                    if (hours >= 24) hours -= 24;
+
+                    return $"{hours}:{minutes:00}";
+                }
+            } 
         }
 
         /// <summary>


### PR DESCRIPTION
This Pull Request adds a new config flag "Use24HourFormat".
If it is set to true, the time will be announced in the 24 hoursformat.
The flag defaults to false.