### PR TITLE
Commands & Features pages update

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,53 +1,45 @@
 # Commands
 
-This page contains the list of all commands added by the mod.
-You can install the [Chat Commands](https://www.nexusmods.com/stardewvalley/mods/2092) mod which will enable entering
-the commands from the in-game chat box instead of using the terminal.
-For a list of commands added by SMAPI, you can visit the [Console commands](https://stardewvalleywiki.com/Modding:Console_commands) page.
+This page contains the list of all commands added by Stardew Access.
+For a list of SMAPI commands, visit the [Console commands](https://stardewvalleywiki.com/Modding:Console_commands) page. You **must** have the Console Commands mod. If you have removed it, get it back by reinstalling SMAPI.
 
 ## Table Of Contents
 
-* [Custom Commands List](#custom-commands-list)
-    * [Read tile related](#read-tile-related)
-    * [Building related](#building-related)
-    * [Other](#other)
-    * [Radar related](#radar-related)
-* [Other Pages](#other-pages)
+- [Tile Reader Commands](#tile-reader-commands)
+- [Building Commands](#building-commands)
+- [Narration & Verbosity Commands](#narration--verbosity-commands)
+- [Radar Commands](#radar-commands)
+- [Miscellaneous Commands](#miscellaneous-commands)
+- [Other Pages](#other-pages)
 
-## Custom Commands List
-
-### Read tile related
+## Tile Reader Commands
 
 | Command  | Description                                    |
 |----------|------------------------------------------------|
 | readtile | Toggle Read Tile feature                       |
+| snapmouse  | Toggle Snap Mouse Feature                                        |
 | flooring | Toggle reading flooring                        |
 | watered  | Toggle speaking watered or unwatered for crops |
 
-### Building related
+## Building Commands
 
 | Command   | Description                                                                                         | Special Syntax (If any)                  | Argument details (If any)                                                                                                         | Example      |
 |-----------|-----------------------------------------------------------------------------------------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------|
-| mark      | Marks the player's position for use in building construction in Carpenter Menu                      | mark [Index:number]                      | Index: the index at which we want to save the position. From 0 to 9 only                                                          | mark 0       |
+| mark      | Marks the player's current position at a specified index                      | mark [Index:number]                      | Index: the desired index to save the position (0 - 9)                                                          | mark 0       |
 | marklist  | List all marked positions                                                                           |                                          |                                                                                                                                   | marklist     |
-| buildlist | List all buildings for selection for upgrading/demolishing/painting                                 |                                          |                                                                                                                                   | buildlist    |
-| buildsel  | Select the building index which you want to upgrade, demolish and paint.                            | buildsel [Index:number]                  | Index: the index of the building we want to select, use buildlist command to list the buildings with their index                  | buildsel 3   |
-| buildsel  | Select the marked position index where we want to construct the building.                           | buildsel [Index:number]                  | Index: the index of the marked position, use marklist command to list the marked positions with their index                       | buildsel 0   |
-| buildsel  | Select the building index along with a index of marked position where we want to move the building. | buildsel [Index1:number] [Index2:number] | Index1: the index of the building we want to select. Index2: the index of the marked position where we want to move the building. | buildsel 3 0 |
+| buildlist | List all buildings for selection                                 |                                          |                                                                                                                                   | buildlist    |
+| buildsel  | Select the index of a building to place a farm animal in the desired building                            | buildsel [Index:number]                  | Index: the index of the building we want to select, use buildlist command to list the buildings with their index                  | buildsel 3   |
 
-### Other
+## Narration & Verbosity Commands
 
 | Command    | Description                                                      |
 |------------|------------------------------------------------------------------|
-| snapmouse  | Toggle Snap Mouse Feature                                        |
 | hnspercent | Toggle between speaking in percentage or full health and stamina |
 | warning    | Toggle warnings feature                                          |
 | tts        | Toggles the screen reader/tts                                    |
 | refsr      | Refreshes screen reader                                          |
-| refst      | (Temporarily disabled) Refreshes static tiles json file          |
-| refmc      | Refreshes mod config json file                                   |
 
-### Radar related
+## Radar Commands
 
 | Command  | Description                                                    |
 |----------|----------------------------------------------------------------|
@@ -67,6 +59,13 @@ For a list of commands added by SMAPI, you can visit the [Console commands](http
 | rflist   | List all the focus in the radar feature                        |
 | rfclear  | Remove all keys from the focus list in the radar feature       |
 | rfcount  | Number of focus in the radar feature                           |
+
+## Miscellaneous Commands
+
+| Command    | Description                                                      |
+|------------|------------------------------------------------------------------|
+| refst      | (Temporarily disabled) Refreshes static tiles json file          |
+| refmc      | Refreshes mod config json file                                   |
 
 ## Other Pages
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,99 +2,108 @@
 
 ## Table Of Contents
 
-* [Table Of Contents](#table-of-contents)
-* [Feature List](#feature-list)
-    * [Read Tile](#read-tile)
-    * [Tile Viewer](#tile-viewer)
-    * [Tile Info Menu](#tile-info-menu)
-    * [Object Tracker](#object-tracker)
-    * [Grid Movement](#grid-movement)
-    * [Warning](#warning)
-    * [Others](#others)
-    * [Radar](#radar)
-* [Other Pages](#other-pages)
+- [Game Narration](#game-narration)
+- [Tile Reader](#tile-reader)
+    - [Tile Viewer](#tile-viewer)
+    - [Tile Info Menu](#tile-info-menu)
+- [Object Tracker](#object-tracker)
+    - [Object Tracker Favorites](#object-tracker-favorites)
+- [Grid Movement](#grid-movement)
+- [Radar](#radar)
+- [Other Pages](#other-pages)
 
-## Feature List
+## Game Narration
 
-### Read Tile
+Stardew Access uses your screen reader to narrate the game as you play, this includes objects, menus, inventories, shops, character dialogue, and more. Some information is narrated on request: the player's map and coordinates, health and energy, currency, and more To convey all of your stats exactly when you need them.
+Warnings are also included for full inventory, low health, low energy, and being out very late.
 
-Reads the name and information about the tile the player is currently facing (not the one the player is standing on).
-This feature uses in-game methods/properties to get the name and information of the object on the tile.
-Many tiles don't have textual information so for that, the mod uses a json file to get the name of the tile.
-You can find this file in the `assets/TilesData` folder by the name `tiles.json`.
-You can also create a `tiles_user.json` file in the `assets/TilesData` folder and add new entries which can also be made
-to work
-only when a certain mod(s) is installed or on a specific farm type, etc.
-You don't have to manually enter the entries, you can use the Tile Info Menu for that
-but there will be a guide for manually adding entries into the `tiles_user.json` file soon.
+**Important Notes:**
 
-See
-related: [keybindings](keybindings.md#global-keys), [commands](commands.md#read-tile-related), [configs](config.md#read-tile-configs).
+1. Narration may be interrupted due to your screen reader's configuration
+    - If using NVDA, ensure that "sleep mode" is turned on or that "Speech Interrupt for Typed Characters" in NVDA's keyboard settings section is turned off. It is recommended to set up a profile to do this automatically [NVDA user guide section 12.4: Profiles](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#ConfigurationProfiles).
+<!--todo: document procedures for other platforms-->
+
+For more information, see the following pages:
+
+- [Keys](keybindings.md#global-keys)
+- [Narration & Verbosity Configs](config.md#narration--verbosity-configs)
+
+## Tile Reader
+
+This feature set makes up the core of Stardew Access. It reads the tile that the player is currently facing by getting the tile's info internally.
+Extra tile information can be added via `tiles.json` located in `assets/TilesData` directory.
+You may also create `tiles_user.json` in `assets/TilesData` directory to add new entries via the tile info menu in-game. these entries may be made dependent on certain mods, farm types, and other options.
+
+<!--todo: add manual user.json guide-->
 
 ### Tile Viewer
 
-Allows browsing of the map and snapping mouse to tiles with the arrow keys.
-This Feature can be used to place items into the world like calendar.
-We can press the `AutoWalkToTileKey` (default to left control + enter) to auto walk the player to that tile (if
-possible).
-Pressing the `OpenTileInfoMenuKey` (default to left shift + enter) to open the tile info menu for the active tile.
+This feature extends the tile reader by allowing you to move the tile cursor anywhere on the active map. This feature is handy for exploring, placing items, selecting tiles, and quickly adding and removing items to machines.
+You may also walk to selected tiles with a keystroke, open the tile info menu to get more info about any objects, or add custom tile info to a selected tile.
 
-See related: [keybindings](keybindings.md#tile-viewer-keys), [configs](config.md#tile-viewer-configs).
+**Important Notes:**
+
+1. For better navigation and mouse button simulation, the cursor is automatically snapped to the tile that the player is looking at unless relative cursor lock has been enabled.
+2. Minimizing or otherwise unfocusing the window without pausing will cause this feature to temporarily stop working when you return to the window. To prevent this, always pause the game before switching to another window.
 
 ### Tile Info Menu
 
-Can be opened by using the `OpenTileInfoMenuKey` (default to Left Shift + Enter) while using the tile viewer.
-The menu contains an option to mark a tile for the various building related operations.
-Another option to add entries in the `tiles_user.json` for a tile.
+This menu is opened with `left ctrl + enter` and allows you to mark the tile's coordinates for future reference, add the tile to custom tile data, and speak detailed tile info.
 
-**Current Limitations:**
+**Important notes:**
 
 1. The third option, the one that should speak the details about the tile only speaks the tile's name.
 2. We can only have one mod as a dependency although having multiple in the `tiles_user.json` is supported.
 3. We can only set the currently ongoing event or the current farm type as dependency.
 4. Festivals are not properly detected.
 
-### Object Tracker
+For more information about all tile reader features, including the tile info menu, see the following pages:
 
-Allows finding and tracking down objects on the map.
-This feature also allows to auto navigate to an object or speaks it's relative distance from the player.
+- [Tile Viewer Keys](keybindings.md#tile-viewer-keys)
+- [Tile Viewer Configs](config.md#tile-viewer-configs)
+- [Global & Tile Reader Keybindings](keybindings.md#global-keys)
+- [Tile Reader Commands](commands.md#tile-reader-commands)
 
-See related: [keybindings](keybindings.md#object-tracker-keys), [configs](config.md#object-tracker-configs).
+## Object Tracker
 
-### Grid Movement
+This feature set allows you to track individual objects on the map. from doorways to forageables to animals and slimes, the object tracker sorts everything into categories and provides a list of everything on the map, sorted by proximity.
+You can get coordinates, distance, and auto-travel to the nearest instance of the selected object.
 
-When enabled, the player moves tile by tile instead of freely.
-This feature is most helpful when planting/harvesting crops or in any case where precise movement is required.
+### Object Tracker Favorites
 
-_Note: In case you encounter the player moving more than one step or the speed being faster than usual,
-try reducing the speed of grid movement from the config._
+Set frequently-traveled spots as a favorite. With 10 favorites per stack and an effectively-limitless set of stacks of favorites per map, you can efficiently get anywhere you need to.
 
-See related: [keybindings](keybindings.md#grid-movement-keys), [configs](config.md#grid-movement-configs).
+For more information about the object tracker feature set, including object tracker favorites, see the following pages:
 
-### Warning
+- [Object Tracker Keys](keybindings.md#object-tracker-keys)
+- [Object Tracker configs](config.md#object-tracker-configs)
 
-Warns the player when their health or stamina/energy is low.
-Also warns when its past midnight.
+## Grid Movement
 
-### Others
+When enabled, the player moves 1 tile at a time and makes a footstep sound on every movement. This feature is very handy when precise movement is required, such as when planting or harvesting crops.
 
-Almost all the vanilla menus are patched to be made accessible by the mod.
-For better navigation and mouse button simulation, the mod snaps the cursor to the tile adjacent to the player based on
-where the player is looking.
-If you switch or minimize the game's window while it is still not paused, this feature will prevent the cursor from
-moving.
-So be sure to pause the game or open any menu before switching/minimizing the window.
-The mod also adds a few keybindings to speak player's current position, location, health, etc.
-See the keybindings page for these keybinds.
+**Important notes:**
 
-### Radar
+1. In case you encounter the player moving more than one step or the speed being faster than usual,
+try reducing the speed of grid movement from the config.
 
-_Note that this is kinda an experimental feature so any feedback on how to improve this feature will be helpful_
+For more information, see the following pages:
 
-Plays a sound at point of interest nearby, like chest, doors, harvestable item, etc.
-The game not supporting stereo sound makes this feature somewhat confusing.
+- [Grid Movement Keys](keybindings.md#grid-movement-keys)
+- [Grid Movement Configs](config.md#grid-movement-configs)
 
-See related: [commands](commands.md#radar-related), [configs](config.md#radar-configs).
+## Radar
+
+This feature will play auditory beacons at the location of the nearest selected object.
+
+**Important Notes:**
+
+1. This feature is experimental and not well-developed and is not recommended for general gameplay.
+
+For more information, see the following pages:
+
+- [Radar Commands](commands.md#radar-commands)
+- [Radar Configs](config.md#radar-configs)
 
 ## Other Pages
 

--- a/stardew-access/compiled-docs/commands.html
+++ b/stardew-access/compiled-docs/commands.html
@@ -1,27 +1,20 @@
 <h1 id="commands">Commands</h1>
 
-<p>This page contains the list of all commands added by the mod.
-You can install the <a href="https://www.nexusmods.com/stardewvalley/mods/2092">Chat Commands</a> mod which will enable entering
-the commands from the in-game chat box instead of using the terminal.
-For a list of commands added by SMAPI, you can visit the <a href="https://stardewvalleywiki.com/Modding:Console_commands">Console commands</a> page.</p>
+<p>This page contains the list of all commands added by Stardew Access.
+For a list of SMAPI commands, visit the <a href="https://stardewvalleywiki.com/Modding:Console_commands">Console commands</a> page. You <strong>must</strong> have the Console Commands mod. If you have removed it, get it back by reinstalling SMAPI.</p>
 
 <h2 id="table-of-contents">Table Of Contents</h2>
 
 <ul>
-  <li><a href="#custom-commands-list">Custom Commands List</a>
-    <ul>
-      <li><a href="#read-tile-related">Read tile related</a></li>
-      <li><a href="#building-related">Building related</a></li>
-      <li><a href="#other">Other</a></li>
-      <li><a href="#radar-related">Radar related</a></li>
-    </ul>
-  </li>
+  <li><a href="#tile-reader-commands">Tile Reader Commands</a></li>
+  <li><a href="#building-commands">Building Commands</a></li>
+  <li><a href="#narration--verbosity-commands">Narration &amp; Verbosity Commands</a></li>
+  <li><a href="#radar-commands">Radar Commands</a></li>
+  <li><a href="#miscellaneous-commands">Miscellaneous Commands</a></li>
   <li><a href="#other-pages">Other Pages</a></li>
 </ul>
 
-<h2 id="custom-commands-list">Custom Commands List</h2>
-
-<h3 id="read-tile-related">Read tile related</h3>
+<h2 id="tile-reader-commands">Tile Reader Commands</h2>
 
 <table>
   <thead>
@@ -36,6 +29,10 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
       <td>Toggle Read Tile feature</td>
     </tr>
     <tr>
+      <td>snapmouse</td>
+      <td>Toggle Snap Mouse Feature</td>
+    </tr>
+    <tr>
       <td>flooring</td>
       <td>Toggle reading flooring</td>
     </tr>
@@ -46,7 +43,7 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
   </tbody>
 </table>
 
-<h3 id="building-related">Building related</h3>
+<h2 id="building-commands">Building Commands</h2>
 
 <table>
   <thead>
@@ -61,9 +58,9 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
   <tbody>
     <tr>
       <td>mark</td>
-      <td>Marks the player’s position for use in building construction in Carpenter Menu</td>
+      <td>Marks the player’s current position at a specified index</td>
       <td>mark [Index:number]</td>
-      <td>Index: the index at which we want to save the position. From 0 to 9 only</td>
+      <td>Index: the desired index to save the position (0 - 9)</td>
       <td>mark 0</td>
     </tr>
     <tr>
@@ -75,36 +72,22 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
     </tr>
     <tr>
       <td>buildlist</td>
-      <td>List all buildings for selection for upgrading/demolishing/painting</td>
+      <td>List all buildings for selection</td>
       <td> </td>
       <td> </td>
       <td>buildlist</td>
     </tr>
     <tr>
       <td>buildsel</td>
-      <td>Select the building index which you want to upgrade, demolish and paint.</td>
+      <td>Select the index of a building to place a farm animal in the desired building</td>
       <td>buildsel [Index:number]</td>
       <td>Index: the index of the building we want to select, use buildlist command to list the buildings with their index</td>
       <td>buildsel 3</td>
     </tr>
-    <tr>
-      <td>buildsel</td>
-      <td>Select the marked position index where we want to construct the building.</td>
-      <td>buildsel [Index:number]</td>
-      <td>Index: the index of the marked position, use marklist command to list the marked positions with their index</td>
-      <td>buildsel 0</td>
-    </tr>
-    <tr>
-      <td>buildsel</td>
-      <td>Select the building index along with a index of marked position where we want to move the building.</td>
-      <td>buildsel [Index1:number] [Index2:number]</td>
-      <td>Index1: the index of the building we want to select. Index2: the index of the marked position where we want to move the building.</td>
-      <td>buildsel 3 0</td>
-    </tr>
   </tbody>
 </table>
 
-<h3 id="other">Other</h3>
+<h2 id="narration--verbosity-commands">Narration &amp; Verbosity Commands</h2>
 
 <table>
   <thead>
@@ -114,10 +97,6 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>snapmouse</td>
-      <td>Toggle Snap Mouse Feature</td>
-    </tr>
     <tr>
       <td>hnspercent</td>
       <td>Toggle between speaking in percentage or full health and stamina</td>
@@ -134,18 +113,10 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
       <td>refsr</td>
       <td>Refreshes screen reader</td>
     </tr>
-    <tr>
-      <td>refst</td>
-      <td>(Temporarily disabled) Refreshes static tiles json file</td>
-    </tr>
-    <tr>
-      <td>refmc</td>
-      <td>Refreshes mod config json file</td>
-    </tr>
   </tbody>
 </table>
 
-<h3 id="radar-related">Radar related</h3>
+<h2 id="radar-commands">Radar Commands</h2>
 
 <table>
   <thead>
@@ -218,6 +189,27 @@ For a list of commands added by SMAPI, you can visit the <a href="https://starde
     <tr>
       <td>rfcount</td>
       <td>Number of focus in the radar feature</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="miscellaneous-commands">Miscellaneous Commands</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Command</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>refst</td>
+      <td>(Temporarily disabled) Refreshes static tiles json file</td>
+    </tr>
+    <tr>
+      <td>refmc</td>
+      <td>Refreshes mod config json file</td>
     </tr>
   </tbody>
 </table>

--- a/stardew-access/compiled-docs/features.html
+++ b/stardew-access/compiled-docs/features.html
@@ -3,56 +3,71 @@
 <h2 id="table-of-contents">Table Of Contents</h2>
 
 <ul>
-  <li><a href="#table-of-contents">Table Of Contents</a></li>
-  <li><a href="#feature-list">Feature List</a>
+  <li><a href="#game-narration">Game Narration</a></li>
+  <li><a href="#tile-reader">Tile Reader</a>
     <ul>
-      <li><a href="#read-tile">Read Tile</a></li>
       <li><a href="#tile-viewer">Tile Viewer</a></li>
       <li><a href="#tile-info-menu">Tile Info Menu</a></li>
-      <li><a href="#object-tracker">Object Tracker</a></li>
-      <li><a href="#grid-movement">Grid Movement</a></li>
-      <li><a href="#warning">Warning</a></li>
-      <li><a href="#others">Others</a></li>
-      <li><a href="#radar">Radar</a></li>
     </ul>
   </li>
+  <li><a href="#object-tracker">Object Tracker</a>
+    <ul>
+      <li><a href="#object-tracker-favorites">Object Tracker Favorites</a></li>
+    </ul>
+  </li>
+  <li><a href="#grid-movement">Grid Movement</a></li>
+  <li><a href="#radar">Radar</a></li>
   <li><a href="#other-pages">Other Pages</a></li>
 </ul>
 
-<h2 id="feature-list">Feature List</h2>
+<h2 id="game-narration">Game Narration</h2>
 
-<h3 id="read-tile">Read Tile</h3>
+<p>Stardew Access uses your screen reader to narrate the game as you play, this includes objects, menus, inventories, shops, character dialogue, and more. Some information is narrated on request: the player’s map and coordinates, health and energy, currency, and more To convey all of your stats exactly when you need them.
+Warnings are also included for full inventory, low health, low energy, and being out very late.</p>
 
-<p>Reads the name and information about the tile the player is currently facing (not the one the player is standing on).
-This feature uses in-game methods/properties to get the name and information of the object on the tile.
-Many tiles don’t have textual information so for that, the mod uses a json file to get the name of the tile.
-You can find this file in the <code>assets/TilesData</code> folder by the name <code>tiles.json</code>.
-You can also create a <code>tiles_user.json</code> file in the <code>assets/TilesData</code> folder and add new entries which can also be made
-to work
-only when a certain mod(s) is installed or on a specific farm type, etc.
-You don’t have to manually enter the entries, you can use the Tile Info Menu for that
-but there will be a guide for manually adding entries into the <code>tiles_user.json</code> file soon.</p>
+<p><strong>Important Notes:</strong></p>
 
-<p>See
-related: <a href="keybindings.html#global-keys">keybindings</a>, <a href="commands.html#read-tile-related">commands</a>, <a href="config.html#read-tile-configs">configs</a>.</p>
+<ol>
+  <li>Narration may be interrupted due to your screen reader’s configuration
+    <ul>
+      <li>If using NVDA, ensure that “sleep mode” is turned on or that “Speech Interrupt for Typed Characters” in NVDA’s keyboard settings section is turned off. It is recommended to set up a profile to do this automatically <a href="https://www.nvaccess.org/files/nvda/documentation/userGuide.html#ConfigurationProfiles">NVDA user guide section 12.4: Profiles</a>.
+<!--todo: document procedures for other platforms--></li>
+    </ul>
+  </li>
+</ol>
+
+<p>For more information, see the following pages:</p>
+
+<ul>
+  <li><a href="keybindings.html#global-keys">Keys</a></li>
+  <li><a href="config.html#narration--verbosity-configs">Narration &amp; Verbosity Configs</a></li>
+</ul>
+
+<h2 id="tile-reader">Tile Reader</h2>
+
+<p>This feature set makes up the core of Stardew Access. It reads the tile that the player is currently facing by getting the tile’s info internally.
+Extra tile information can be added via <code>tiles.json</code> located in <code>assets/TilesData</code> directory.
+You may also create <code>tiles_user.json</code> in <code>assets/TilesData</code> directory to add new entries via the tile info menu in-game. these entries may be made dependent on certain mods, farm types, and other options.</p>
+
+<!--todo: add manual user.json guide-->
 
 <h3 id="tile-viewer">Tile Viewer</h3>
 
-<p>Allows browsing of the map and snapping mouse to tiles with the arrow keys.
-This Feature can be used to place items into the world like calendar.
-We can press the <code>AutoWalkToTileKey</code> (default to left control + enter) to auto walk the player to that tile (if
-possible).
-Pressing the <code>OpenTileInfoMenuKey</code> (default to left shift + enter) to open the tile info menu for the active tile.</p>
+<p>This feature extends the tile reader by allowing you to move the tile cursor anywhere on the active map. This feature is handy for exploring, placing items, selecting tiles, and quickly adding and removing items to machines.
+You may also walk to selected tiles with a keystroke, open the tile info menu to get more info about any objects, or add custom tile info to a selected tile.</p>
 
-<p>See related: <a href="keybindings.html#tile-viewer-keys">keybindings</a>, <a href="config.html#tile-viewer-configs">configs</a>.</p>
+<p><strong>Important Notes:</strong></p>
+
+<ol>
+  <li>For better navigation and mouse button simulation, the cursor is automatically snapped to the tile that the player is looking at unless relative cursor lock has been enabled.</li>
+  <li>Minimizing or otherwise unfocusing the window without pausing will cause this feature to temporarily stop working when you return to the window. To prevent this, always pause the game before switching to another window.</li>
+</ol>
 
 <h3 id="tile-info-menu">Tile Info Menu</h3>
 
-<p>Can be opened by using the <code>OpenTileInfoMenuKey</code> (default to Left Shift + Enter) while using the tile viewer.
-The menu contains an option to mark a tile for the various building related operations.
-Another option to add entries in the <code>tiles_user.json</code> for a tile.</p>
+<p>This menu is opened with <code>left ctrl + enter</code> and allows you to mark the tile’s coordinates for future reference, add the tile to custom tile data, and speak detailed tile info.</p>
 
-<p><strong>Current Limitations:</strong></p>
+<p><strong>Important notes:</strong></p>
 
 <ol>
   <li>The third option, the one that should speak the details about the tile only speaks the tile’s name.</li>
@@ -61,47 +76,65 @@ Another option to add entries in the <code>tiles_user.json</code> for a tile.</p
   <li>Festivals are not properly detected.</li>
 </ol>
 
-<h3 id="object-tracker">Object Tracker</h3>
+<p>For more information about all tile reader features, including the tile info menu, see the following pages:</p>
 
-<p>Allows finding and tracking down objects on the map.
-This feature also allows to auto navigate to an object or speaks it’s relative distance from the player.</p>
+<ul>
+  <li><a href="keybindings.html#tile-viewer-keys">Tile Viewer Keys</a></li>
+  <li><a href="config.html#tile-viewer-configs">Tile Viewer Configs</a></li>
+  <li><a href="keybindings.html#global-keys">Global &amp; Tile Reader Keybindings</a></li>
+  <li><a href="commands.html#tile-reader-commands">Tile Reader Commands</a></li>
+</ul>
 
-<p>See related: <a href="keybindings.html#object-tracker-keys">keybindings</a>, <a href="config.html#object-tracker-configs">configs</a>.</p>
+<h2 id="object-tracker">Object Tracker</h2>
 
-<h3 id="grid-movement">Grid Movement</h3>
+<p>This feature set allows you to track individual objects on the map. from doorways to forageables to animals and slimes, the object tracker sorts everything into categories and provides a list of everything on the map, sorted by proximity.
+You can get coordinates, distance, and auto-travel to the nearest instance of the selected object.</p>
 
-<p>When enabled, the player moves tile by tile instead of freely.
-This feature is most helpful when planting/harvesting crops or in any case where precise movement is required.</p>
+<h3 id="object-tracker-favorites">Object Tracker Favorites</h3>
 
-<p><em>Note: In case you encounter the player moving more than one step or the speed being faster than usual,
-try reducing the speed of grid movement from the config.</em></p>
+<p>Set frequently-traveled spots as a favorite. With 10 favorites per stack and an effectively-limitless set of stacks of favorites per map, you can efficiently get anywhere you need to.</p>
 
-<p>See related: <a href="keybindings.html#grid-movement-keys">keybindings</a>, <a href="config.html#grid-movement-configs">configs</a>.</p>
+<p>For more information about the object tracker feature set, including object tracker favorites, see the following pages:</p>
 
-<h3 id="warning">Warning</h3>
+<ul>
+  <li><a href="keybindings.html#object-tracker-keys">Object Tracker Keys</a></li>
+  <li><a href="config.html#object-tracker-configs">Object Tracker configs</a></li>
+</ul>
 
-<p>Warns the player when their health or stamina/energy is low.
-Also warns when its past midnight.</p>
+<h2 id="grid-movement">Grid Movement</h2>
 
-<h3 id="others">Others</h3>
+<p>When enabled, the player moves 1 tile at a time and makes a footstep sound on every movement. This feature is very handy when precise movement is required, such as when planting or harvesting crops.</p>
 
-<p>Almost all the vanilla menus are patched to be made accessible by the mod.
-For better navigation and mouse button simulation, the mod snaps the cursor to the tile adjacent to the player based on
-where the player is looking.
-If you switch or minimize the game’s window while it is still not paused, this feature will prevent the cursor from
-moving.
-So be sure to pause the game or open any menu before switching/minimizing the window.
-The mod also adds a few keybindings to speak player’s current position, location, health, etc.
-See the keybindings page for these keybinds.</p>
+<p><strong>Important notes:</strong></p>
 
-<h3 id="radar">Radar</h3>
+<ol>
+  <li>In case you encounter the player moving more than one step or the speed being faster than usual,
+try reducing the speed of grid movement from the config.</li>
+</ol>
 
-<p><em>Note that this is kinda an experimental feature so any feedback on how to improve this feature will be helpful</em></p>
+<p>For more information, see the following pages:</p>
 
-<p>Plays a sound at point of interest nearby, like chest, doors, harvestable item, etc.
-The game not supporting stereo sound makes this feature somewhat confusing.</p>
+<ul>
+  <li><a href="keybindings.html#grid-movement-keys">Grid Movement Keys</a></li>
+  <li><a href="config.html#grid-movement-configs">Grid Movement Configs</a></li>
+</ul>
 
-<p>See related: <a href="commands.html#radar-related">commands</a>, <a href="config.html#radar-configs">configs</a>.</p>
+<h2 id="radar">Radar</h2>
+
+<p>This feature will play auditory beacons at the location of the nearest selected object.</p>
+
+<p><strong>Important Notes:</strong></p>
+
+<ol>
+  <li>This feature is experimental and not well-developed and is not recommended for general gameplay.</li>
+</ol>
+
+<p>For more information, see the following pages:</p>
+
+<ul>
+  <li><a href="commands.html#radar-commands">Radar Commands</a></li>
+  <li><a href="config.html#radar-configs">Radar Configs</a></li>
+</ul>
 
 <h2 id="other-pages">Other Pages</h2>
 


### PR DESCRIPTION
This revamps commands and features to be much more readable, include more resources, and include the updated feature sets. In features, I added a note on how to solve the issue of your  screen reader having the narration cut off after you press a key, but I only included a procedure for NVDA users. I can test on Mac OS with Voiceover, but I have no way of testing if a procedure is needed with JAWS or Linux. Contributions from those with systems who can test for those is welcome