### PR TITLE
Setup guide addition

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [Installation Directory Quick Reference](#installation-directory-quick-reference)
 - [Automatic Installation (Recommended)](#automatic-installation-recommended)
 - [Manual Installation](#manual-installation)
     - [Requirements](#requirements)
@@ -20,20 +21,36 @@
 - [Other Mods](#other-mods)
 - [Other Pages](#other-pages)
 
+## Installation Directory Quick Reference
+
+- Windows
+    - Steam: `C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley`
+    - Xbox App: `C:\Program Files\ModifiableWindowsApps\Stardew Valley`
+    - GOG: `C:\Program Files (x86)\GOG Galaxy\Games\Stardew Valley`
+- Mac OS
+    - Steam: `~/Library/Application Support/Steam/SteamApps/common/Stardew Valley/Contents/MacOS`
+    - GOG: `/Applications/Stardew Valley.app/Contents/MacOS`
+- Linux
+    - GOG: `~/GOGGames/StardewValley/game`
+    - Steam: `~/.local/share/Steam/steamapps/common/Stardew Valley`
+
 ## Automatic Installation (Recommended)
 
-1. Install Stardew Valley through your preferred game platform
-2. Download the [automatic installer]()
-3. Follow the instructions that appear in the installer
-4. Once the installer finishes, select finish and enjoy Stardew Access
+The purpose of the Accessible Stardew Setup installer is to quickly and easily install the minimum required mods for blind players to enjoy Stardew Valley. If you wish to install additional mods that are not directly related to low-vision accessibility, you may do so manually. If you wish to install SMAPI, Stardew Access, and its dependencies manually, proceed to [manual installation](#manual-installation), otherwise follow the steps below:
 
-**Optional:** [integrate with your game client for achievements](#integrating-with-your-game-client)
+1. Install Stardew Valley through your preferred game platform
+2. Download Accessible Stardew Setup (ASS). [get ASS here](https://github.com/ParadoxiKat/AccessibleStardewSetup/releases/latest)
+3. Follow the instructions that appear in the installer
+4. Once the installer completes installation, select finish and enjoy Stardew Access
+
+**Optional Step For non Steam Users:** [integrate with your game client for achievements](#integrating-with-your-game-client)
 
 - [Xbox](#xbox-app)
-- [Steam](#steam)
 - [GOG Galaxy](#gog-galaxy)
 
 ## Manual Installation
+
+If you prefer to install SMAPI, Stardew Access, and its dependencies manually, you may follow the instructions below.
 
 ### Requirements
 
@@ -87,19 +104,23 @@ If you do not complete this step, you must launch Stardew Valley via `StardewMod
 
 ###### Xbox App
 
-This process is done automatically for Xbox users when installing SMAPI.
+This process is done when installing SMAPI on an Xbox App copy.
 
 ###### Steam
 
-**Note:** This process is very difficult to do without vision. Steam has bad accessibility under the best of conditions.
-
-1. Open the `properties` for Stardew (you can do this by right clicking the game in the library and then
-   selecting `properties` from the drop down list)
-2. Go to the `Launch Options` in the `General` tab and paste the following line:
-    - `"{Stardew Valley Folder path}\StardewModdingAPI.exe" %command%`
-    - Replace the `{Stardew Valley Folder path}` with the correct path.
-    - Default for most users
-      is: `"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe" %command%`
+1. Ensure Steam is running
+2. Move to the system tray with `windows + b`, press "show hidden icons" to show the full system tray, and find "Steam" in the icon grid
+3. Press `enter` on Steam to open the tray menu and move down the menu until you find "Big Picture"
+4. Enter Big Picture mode and enable focus mode in NVDA
+5. Use the arrow keys to move around the Big Picture interface and find the grid of games
+6. Locate "Stardew Valley" and open the context menu with the applications key or with `shift + f10`
+    - As an alternative, focus on Stardew Valley in the grid, use `NVDA + numpad divide` to route the mouse cursor to the element, and then use `numpad multiply` to right-click and open the context menu
+7. In the context menu, find and select "properties"
+8. Ensure you are focused on the "General" tab in the new window and press `right arrow` to enter the general section
+    - If you are not using focus mode, you may either press `e` to move to the text box described in step 9 or disable automatic move of the system focus due to browse mode commands" with `NVDA + 8` and use the down arrow immediately to find the text box described in step 9
+9. Arrow down until you come across a text box located shortly after a button labeled "default" and paste the following text:
+    - `"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe" %command%`
+10. Once you have entered the text, exit Big Picture mode with `alt + f4`. The text you just entered is saved automatically
 
 ###### GOG Galaxy
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,33 +2,48 @@
 
 ## Table of Contents
 
-- [Requirements](#requirements)
-- [SMAPI setup](#smapi-setup)
-    - [Windows](#windows)
-        - [Xbox App Setup](#xbox-app-setup)
-        - [Integrating with The Game Client](#integrating-with-the-game-client)
-            - [Xbox App](#xbox-app)
-            - [Steam](#steam)
-            - [GOG Galaxy](#gog-galaxy)
-    - [Linux](#linux)
-    - [MacOS](#macos)
-- [Installing Stardew Access](#installing-stardew-access)
-    - [Installing Kokoro and Project Fluent](#installing-kokoro-and-project-fluent)
-- [Updating Stardew Access](#updating-stardew-access)
+- [Automatic Installation (Recommended)](#automatic-installation-recommended)
+- [Manual Installation](#manual-installation)
+    - [Requirements](#requirements)
+    - [SMAPI setup](#smapi-setup)
+        - [Windows](#windows)
+            - [Xbox App Setup](#xbox-app-setup)
+            - [Integrating with Your Game Client](#integrating-with-your-game-client)
+                - [Xbox App](#xbox-app)
+                - [Steam](#steam)
+                - [GOG Galaxy](#gog-galaxy)
+        - [Linux](#linux)
+        - [MacOS](#macos)
+    - [Installing Stardew Access](#installing-stardew-access)
+        - [Installing Kokoro and Project Fluent](#installing-kokoro-and-project-fluent)
+    - [Updating Stardew Access](#updating-stardew-access)
 - [Other Mods](#other-mods)
-    - [Essentials](#essentials)
-    - [Recommended](#recommended)
 - [Other Pages](#other-pages)
 
-## Requirements
+## Automatic Installation (Recommended)
+
+1. Install Stardew Valley through your preferred game platform
+2. Download the [automatic installer]()
+3. Follow the instructions that appear in the installer
+4. Once the installer finishes, select finish and enjoy Stardew Access
+
+**Optional:** [integrate with your game client for achievements](#integrating-with-your-game-client)
+
+- [Xbox](#xbox-app)
+- [Steam](#steam)
+- [GOG Galaxy](#gog-galaxy)
+
+## Manual Installation
+
+### Requirements
 
 1. [SMAPI](#smapi-setup)
 2. [Kokoro](#installing-kokoro-and-project-fluent)
 3. [Project Fluent](#installing-kokoro-and-project-fluent)
 
-## SMAPI setup
+### SMAPI setup
 
-### Windows
+#### Windows
 
 **Important Note:** If you are launching the game from the Xbox app, proceed to [Xbox App Setup](#xbox-app-setup), otherwise proceed with the instructions below.
 
@@ -38,7 +53,7 @@
 4. Open the new folder once it has finished unzipping. You may need to open two folders to get to the contents.
 4. Double-click `install on Windows.bat`, and follow the on-screen instructions.
 
-#### Xbox App Setup
+##### Xbox App Setup
 
 **Before installing SMAPI:**
 
@@ -65,16 +80,16 @@ In your game installation directory:
 
 **Important Note:** You must reinstall SMAPI and rename the .exe files each time there is a SMAPI update.
 
-#### Integrating with The Game Client
+##### Integrating with Your Game Client
 
 While this step is optional, it will allow you to use the normal shortcuts to launch Stardew Valley and enable cheats.
 If you do not complete this step, you must launch Stardew Valley via `StardewModdingAPI.exe` for all mods to function. Using the shortcut created by the game installation will not load SMAPI or any mods.
 
-##### Xbox App
+###### Xbox App
 
 This process is done automatically for Xbox users when installing SMAPI.
 
-##### Steam
+###### Steam
 
 **Note:** This process is very difficult to do without vision. Steam has bad accessibility under the best of conditions.
 
@@ -86,7 +101,7 @@ This process is done automatically for Xbox users when installing SMAPI.
     - Default for most users
       is: `"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe" %command%`
 
-##### GOG Galaxy
+###### GOG Galaxy
 
 1. Open Notepad and paste in the following:
     - `start "" "{Stardew Valley Folder path}\StardewModdingAPI.exe"`
@@ -101,7 +116,7 @@ This process is done automatically for Xbox users when installing SMAPI.
 6. Choose `start.bat` in the window that appears and click Open.
 7. Enable the `Default Executable` radio button under the File 2 section you just added, and click OK.
 
-### Linux
+#### Linux
 
 1. On many Linux distributions, you may need to download and install an older version of libssl (1.1 or 1.x).
     - On Ubuntu, Debian, Linux Mint, and other Debian-based installations, install libssl1.1 (by
@@ -116,7 +131,7 @@ This process is done automatically for Xbox users when installing SMAPI.
     - (If the installer asks for your game install path, see how to
        [find your game folder here](https://stardewvalleywiki.com/Modding:Player_Guide/Getting_Started#Find_your_game_folder).)
 
-### MacOS
+#### MacOS
 
 After installing Stardew Valley with Steam:
 
@@ -124,7 +139,7 @@ After installing Stardew Valley with Steam:
 2. Extract the .zip file somewhere (Your downloads folder is fine).
 3. Double-click `install on Mac.command`, and follow the on-screen instructions.
 
-## Installing Stardew Access
+### Installing Stardew Access
 
 Once you have installed at least Stardew Valley and SMAPI:
 
@@ -136,7 +151,7 @@ Once you have installed at least Stardew Valley and SMAPI:
 
 **note:** If you are experiencing bugs, install the debug version of Stardew Access which will generate more logs to help diagnose the problem.
 
-### Installing Kokoro and Project Fluent
+#### Installing Kokoro and Project Fluent
 
 As of v1.5.0, [Kokoro](https://www.nexusmods.com/stardewvalley/mods/15682) and [Project Fluent ](https://www.nexusmods.com/stardewvalley/mods/12638) are now dependencies for
 Stardew access and as such, the mod won't run without
@@ -157,7 +172,7 @@ Installation of Project Fluent and Kokoro is essentially the same as installing 
    [this Nexus direct link](https://www.nexusmods.com/stardewvalley/mods/15682?tab=files&file_id=82817)
 3. Extract both zip files and move the contents of each into the `Mods` folder in your game's folder.
 
-## Updating Stardew Access
+### Updating Stardew Access
 
 To update Stardew Access:
 

--- a/stardew-access/compiled-docs/setup.html
+++ b/stardew-access/compiled-docs/setup.html
@@ -3,6 +3,7 @@
 <h2 id="table-of-contents">Table of Contents</h2>
 
 <ul>
+  <li><a href="#installation-directory-quick-reference">Installation Directory Quick Reference</a></li>
   <li><a href="#automatic-installation-recommended">Automatic Installation (Recommended)</a></li>
   <li><a href="#manual-installation">Manual Installation</a>
     <ul>
@@ -37,24 +38,51 @@
   <li><a href="#other-pages">Other Pages</a></li>
 </ul>
 
+<h2 id="installation-directory-quick-reference">Installation Directory Quick Reference</h2>
+
+<ul>
+  <li>Windows
+    <ul>
+      <li>Steam: <code>C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</code></li>
+      <li>Xbox App: <code>C:\Program Files\ModifiableWindowsApps\Stardew Valley</code></li>
+      <li>GOG: <code>C:\Program Files (x86)\GOG Galaxy\Games\Stardew Valley</code></li>
+    </ul>
+  </li>
+  <li>Mac OS
+    <ul>
+      <li>Steam: <code>~/Library/Application Support/Steam/SteamApps/common/Stardew Valley/Contents/MacOS</code></li>
+      <li>GOG: <code>/Applications/Stardew Valley.app/Contents/MacOS</code></li>
+    </ul>
+  </li>
+  <li>Linux
+    <ul>
+      <li>GOG: <code>~/GOGGames/StardewValley/game</code></li>
+      <li>Steam: <code>~/.local/share/Steam/steamapps/common/Stardew Valley</code></li>
+    </ul>
+  </li>
+</ul>
+
 <h2 id="automatic-installation-recommended">Automatic Installation (Recommended)</h2>
+
+<p>The purpose of the Accessible Stardew Setup installer is to quickly and easily install the minimum required mods for blind players to enjoy Stardew Valley. If you wish to install additional mods that are not directly related to low-vision accessibility, you may do so manually. If you wish to install SMAPI, Stardew Access, and its dependencies manually, proceed to <a href="#manual-installation">manual installation</a>, otherwise follow the steps below:</p>
 
 <ol>
   <li>Install Stardew Valley through your preferred game platform</li>
-  <li>Download the <a href="">automatic installer</a></li>
+  <li>Download Accessible Stardew Setup (ASS). <a href="https://github.com/ParadoxiKat/AccessibleStardewSetup/releases/latest">get ASS here</a></li>
   <li>Follow the instructions that appear in the installer</li>
-  <li>Once the installer finishes, select finish and enjoy Stardew Access</li>
+  <li>Once the installer completes installation, select finish and enjoy Stardew Access</li>
 </ol>
 
-<p><strong>Optional:</strong> <a href="#integrating-with-your-game-client">integrate with your game client for achievements</a></p>
+<p><strong>Optional Step For non Steam Users:</strong> <a href="#integrating-with-your-game-client">integrate with your game client for achievements</a></p>
 
 <ul>
   <li><a href="#xbox-app">Xbox</a></li>
-  <li><a href="#steam">Steam</a></li>
   <li><a href="#gog-galaxy">GOG Galaxy</a></li>
 </ul>
 
 <h2 id="manual-installation">Manual Installation</h2>
+
+<p>If you prefer to install SMAPI, Stardew Access, and its dependencies manually, you may follow the instructions below.</p>
 
 <h3 id="requirements">Requirements</h3>
 
@@ -116,23 +144,33 @@ If you do not complete this step, you must launch Stardew Valley via <code>Stard
 
 <h6 id="xbox-app">Xbox App</h6>
 
-<p>This process is done automatically for Xbox users when installing SMAPI.</p>
+<p>This process is done when installing SMAPI on an Xbox App copy.</p>
 
 <h6 id="steam">Steam</h6>
 
-<p><strong>Note:</strong> This process is very difficult to do without vision. Steam has bad accessibility under the best of conditions.</p>
-
 <ol>
-  <li>Open the <code>properties</code> for Stardew (you can do this by right clicking the game in the library and then
-selecting <code>properties</code> from the drop down list)</li>
-  <li>Go to the <code>Launch Options</code> in the <code>General</code> tab and paste the following line:
+  <li>Ensure Steam is running</li>
+  <li>Move to the system tray with <code>windows + b</code>, press “show hidden icons” to show the full system tray, and find “Steam” in the icon grid</li>
+  <li>Press <code>enter</code> on Steam to open the tray menu and move down the menu until you find “Big Picture”</li>
+  <li>Enter Big Picture mode and enable focus mode in NVDA</li>
+  <li>Use the arrow keys to move around the Big Picture interface and find the grid of games</li>
+  <li>Locate “Stardew Valley” and open the context menu with the applications key or with <code>shift + f10</code>
     <ul>
-      <li><code>"{Stardew Valley Folder path}\StardewModdingAPI.exe" %command%</code></li>
-      <li>Replace the <code>{Stardew Valley Folder path}</code> with the correct path.</li>
-      <li>Default for most users
-is: <code>"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe" %command%</code></li>
+      <li>As an alternative, focus on Stardew Valley in the grid, use <code>NVDA + numpad divide</code> to route the mouse cursor to the element, and then use <code>numpad multiply</code> to right-click and open the context menu</li>
     </ul>
   </li>
+  <li>In the context menu, find and select “properties”</li>
+  <li>Ensure you are focused on the “General” tab in the new window and press <code>right arrow</code> to enter the general section
+    <ul>
+      <li>If you are not using focus mode, you may either press <code>e</code> to move to the text box described in step 9 or disable automatic move of the system focus due to browse mode commands” with <code>NVDA + 8</code> and use the down arrow immediately to find the text box described in step 9</li>
+    </ul>
+  </li>
+  <li>Arrow down until you come across a text box located shortly after a button labeled “default” and paste the following text:
+    <ul>
+      <li><code>"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe" %command%</code></li>
+    </ul>
+  </li>
+  <li>Once you have entered the text, exit Big Picture mode with <code>alt + f4</code>. The text you just entered is saved automatically</li>
 </ol>
 
 <h6 id="gog-galaxy">GOG Galaxy</h6>

--- a/stardew-access/compiled-docs/setup.html
+++ b/stardew-access/compiled-docs/setup.html
@@ -3,41 +3,60 @@
 <h2 id="table-of-contents">Table of Contents</h2>
 
 <ul>
-  <li><a href="#requirements">Requirements</a></li>
-  <li><a href="#smapi-setup">SMAPI setup</a>
+  <li><a href="#automatic-installation-recommended">Automatic Installation (Recommended)</a></li>
+  <li><a href="#manual-installation">Manual Installation</a>
     <ul>
-      <li><a href="#windows">Windows</a>
+      <li><a href="#requirements">Requirements</a></li>
+      <li><a href="#smapi-setup">SMAPI setup</a>
         <ul>
-          <li><a href="#xbox-app-setup">Xbox App Setup</a></li>
-          <li><a href="#integrating-with-the-game-client">Integrating with The Game Client</a>
+          <li><a href="#windows">Windows</a>
             <ul>
-              <li><a href="#xbox-app">Xbox App</a></li>
-              <li><a href="#steam">Steam</a></li>
-              <li><a href="#gog-galaxy">GOG Galaxy</a></li>
+              <li><a href="#xbox-app-setup">Xbox App Setup</a></li>
+              <li><a href="#integrating-with-your-game-client">Integrating with Your Game Client</a>
+                <ul>
+                  <li><a href="#xbox-app">Xbox App</a></li>
+                  <li><a href="#steam">Steam</a></li>
+                  <li><a href="#gog-galaxy">GOG Galaxy</a></li>
+                </ul>
+              </li>
             </ul>
           </li>
+          <li><a href="#linux">Linux</a></li>
+          <li><a href="#macos">MacOS</a></li>
         </ul>
       </li>
-      <li><a href="#linux">Linux</a></li>
-      <li><a href="#macos">MacOS</a></li>
+      <li><a href="#installing-stardew-access">Installing Stardew Access</a>
+        <ul>
+          <li><a href="#installing-kokoro-and-project-fluent">Installing Kokoro and Project Fluent</a></li>
+        </ul>
+      </li>
+      <li><a href="#updating-stardew-access">Updating Stardew Access</a></li>
     </ul>
   </li>
-  <li><a href="#installing-stardew-access">Installing Stardew Access</a>
-    <ul>
-      <li><a href="#installing-kokoro-and-project-fluent">Installing Kokoro and Project Fluent</a></li>
-    </ul>
-  </li>
-  <li><a href="#updating-stardew-access">Updating Stardew Access</a></li>
-  <li><a href="#other-mods">Other Mods</a>
-    <ul>
-      <li><a href="#essentials">Essentials</a></li>
-      <li><a href="#recommended">Recommended</a></li>
-    </ul>
-  </li>
+  <li><a href="#other-mods">Other Mods</a></li>
   <li><a href="#other-pages">Other Pages</a></li>
 </ul>
 
-<h2 id="requirements">Requirements</h2>
+<h2 id="automatic-installation-recommended">Automatic Installation (Recommended)</h2>
+
+<ol>
+  <li>Install Stardew Valley through your preferred game platform</li>
+  <li>Download the <a href="">automatic installer</a></li>
+  <li>Follow the instructions that appear in the installer</li>
+  <li>Once the installer finishes, select finish and enjoy Stardew Access</li>
+</ol>
+
+<p><strong>Optional:</strong> <a href="#integrating-with-your-game-client">integrate with your game client for achievements</a></p>
+
+<ul>
+  <li><a href="#xbox-app">Xbox</a></li>
+  <li><a href="#steam">Steam</a></li>
+  <li><a href="#gog-galaxy">GOG Galaxy</a></li>
+</ul>
+
+<h2 id="manual-installation">Manual Installation</h2>
+
+<h3 id="requirements">Requirements</h3>
 
 <ol>
   <li><a href="#smapi-setup">SMAPI</a></li>
@@ -45,9 +64,9 @@
   <li><a href="#installing-kokoro-and-project-fluent">Project Fluent</a></li>
 </ol>
 
-<h2 id="smapi-setup">SMAPI setup</h2>
+<h3 id="smapi-setup">SMAPI setup</h3>
 
-<h3 id="windows">Windows</h3>
+<h4 id="windows">Windows</h4>
 
 <p><strong>Important Note:</strong> If you are launching the game from the Xbox app, proceed to <a href="#xbox-app-setup">Xbox App Setup</a>, otherwise proceed with the instructions below.</p>
 
@@ -59,7 +78,7 @@
   <li>Double-click <code>install on Windows.bat</code>, and follow the on-screen instructions.</li>
 </ol>
 
-<h4 id="xbox-app-setup">Xbox App Setup</h4>
+<h5 id="xbox-app-setup">Xbox App Setup</h5>
 
 <p><strong>Before installing SMAPI:</strong></p>
 
@@ -90,16 +109,16 @@
 
 <p><strong>Important Note:</strong> You must reinstall SMAPI and rename the .exe files each time there is a SMAPI update.</p>
 
-<h4 id="integrating-with-the-game-client">Integrating with The Game Client</h4>
+<h5 id="integrating-with-your-game-client">Integrating with Your Game Client</h5>
 
 <p>While this step is optional, it will allow you to use the normal shortcuts to launch Stardew Valley and enable cheats.
 If you do not complete this step, you must launch Stardew Valley via <code>StardewModdingAPI.exe</code> for all mods to function. Using the shortcut created by the game installation will not load SMAPI or any mods.</p>
 
-<h5 id="xbox-app">Xbox App</h5>
+<h6 id="xbox-app">Xbox App</h6>
 
 <p>This process is done automatically for Xbox users when installing SMAPI.</p>
 
-<h5 id="steam">Steam</h5>
+<h6 id="steam">Steam</h6>
 
 <p><strong>Note:</strong> This process is very difficult to do without vision. Steam has bad accessibility under the best of conditions.</p>
 
@@ -116,7 +135,7 @@ is: <code>"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewM
   </li>
 </ol>
 
-<h5 id="gog-galaxy">GOG Galaxy</h5>
+<h6 id="gog-galaxy">GOG Galaxy</h6>
 
 <ol>
   <li>Open Notepad and paste in the following:
@@ -136,7 +155,7 @@ to <code>all files</code> when saving.</li>
   <li>Enable the <code>Default Executable</code> radio button under the File 2 section you just added, and click OK.</li>
 </ol>
 
-<h3 id="linux">Linux</h3>
+<h4 id="linux">Linux</h4>
 
 <ol>
   <li>On many Linux distributions, you may need to download and install an older version of libssl (1.1 or 1.x).
@@ -159,7 +178,7 @@ running <code>sudo apt install libssl1.1</code> on a terminal).</li>
   </li>
 </ol>
 
-<h3 id="macos">MacOS</h3>
+<h4 id="macos">MacOS</h4>
 
 <p>After installing Stardew Valley with Steam:</p>
 
@@ -169,7 +188,7 @@ running <code>sudo apt install libssl1.1</code> on a terminal).</li>
   <li>Double-click <code>install on Mac.command</code>, and follow the on-screen instructions.</li>
 </ol>
 
-<h2 id="installing-stardew-access">Installing Stardew Access</h2>
+<h3 id="installing-stardew-access">Installing Stardew Access</h3>
 
 <p>Once you have installed at least Stardew Valley and SMAPI:</p>
 
@@ -183,7 +202,7 @@ from <a href="https://www.nexusmods.com/stardewvalley/mods/16205/?tab=files">Nex
 
 <p><strong>note:</strong> If you are experiencing bugs, install the debug version of Stardew Access which will generate more logs to help diagnose the problem.</p>
 
-<h3 id="installing-kokoro-and-project-fluent">Installing Kokoro and Project Fluent</h3>
+<h4 id="installing-kokoro-and-project-fluent">Installing Kokoro and Project Fluent</h4>
 
 <p>As of v1.5.0, <a href="https://www.nexusmods.com/stardewvalley/mods/15682">Kokoro</a> and <a href="https://www.nexusmods.com/stardewvalley/mods/12638">Project Fluent </a> are now dependencies for
 Stardew access and as such, the mod won’t run without
@@ -209,7 +228,7 @@ updates to Nexus.</li>
   <li>Extract both zip files and move the contents of each into the <code>Mods</code> folder in your game’s folder.</li>
 </ol>
 
-<h2 id="updating-stardew-access">Updating Stardew Access</h2>
+<h3 id="updating-stardew-access">Updating Stardew Access</h3>
 
 <p>To update Stardew Access:</p>
 


### PR DESCRIPTION
This PR provides instructions for how to use the new [Accessible Stardew Setup](https://github.com/ParadoxiKat/AccessibleStardewSetup/). Many blind gamers, especially those who are new to gaming, struggle with manual installation of mods. This offers links to an installer which will install the minimum required mods to make Stardew Valley accessible to blind gamers with a screen reader.

Also, I rewrote the Steam instructions for manually adding game config info to add a procedure that is more screen reader-friendly by going through Big Picture.