### PR TITLE
[June 9] QOL Updates For Shop Menus And Lumber Pile

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -5,7 +5,6 @@
 
 ### Feature Updates
 
-- Detect Pierre's Booth tile in Luau festival.
 - Farm animal's age is spoken in days if it is less than a month old.
 - Animal's info include the baby and hungry statuses.
 - Animal purchase menu:
@@ -22,15 +21,16 @@
 
 ### Translation Changes
 
-- (en.ftl) new: `event_tile-luau-pierre_booth` with English value `Pierre's Booth`
-- (en.ftl) Modified: `npc-farm_animal_info` added `is_hungry`, `is_baby` and `is_age_in_days` attributes, look [here for updated english translation](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/en.ftl#L333-L348)
-- (en.ftl) Added: `tile-town-bookseller` with english value = `Bookseller`
-- (static_tiles.en.ftl) Removed: `static_tile-town-bookseller`
-- (menu.en.ftl) Modified: `menu-animal_query-animal_info` added `is_age_in_days` attribute, look [here for updated english translation](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/menu.en.ftl#L345-L367)
+- New(en.ftl): `event_tile-luau-pierre_booth` with English value `Pierre's Booth`
+- Modified(en.ftl): `npc-farm_animal_info` added `is_hungry`, `is_baby` and `is_age_in_days` attributes, look [here for updated english translation](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/en.ftl#L333-L348)
+- New(en.ftl): `tile-town-bookseller` with english value `Bookseller`
+- Removed(static_tiles.en.ftl): `static_tile-town-bookseller`
+- Modified(menu.en.ftl): `menu-animal_query-animal_info` added `is_age_in_days` attribute, look [here for updated english translation](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/menu.en.ftl#L345-L367)
 
 ### Tile Tracker Changes
 
 - Bookseller's tile is now dynamically tracked.
+- Detect Pierre's Booth tile in Luau festival.
 
 ### Guides And Docs
 
@@ -39,5 +39,5 @@
 
 - Added pull request template
 - ci: As opposed to `/fast-forward`, we can also now use `/fast-forward-force` to merge the PR without checking for `mergeable_state`.
--  Fix if condition failure in fast-forward.yml
+- ci: Fix if condition failure in fast-forward.yml
 

--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -23,7 +23,6 @@
 ### Translation Changes
 
 - (en.ftl) new: `event_tile-luau-pierre_booth` with English value `Pierre's Booth`
-
 - (en.ftl) Modified: `npc-farm_animal_info` added `is_hungry`, `is_baby` and `is_age_in_days` attributes, look [here for updated english translation](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/en.ftl#L333-L348)
 - (en.ftl) Added: `tile-town-bookseller` with english value = `Bookseller`
 - (static_tiles.en.ftl) Removed: `static_tile-town-bookseller`

--- a/stardew-access/Patches/MenuWithInventoryPatches/ShopMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ShopMenuPatch.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using HarmonyLib;
 using stardew_access.Translation;
 using stardew_access.Utils;
@@ -86,6 +87,21 @@ internal class ShopMenuPatch : IPatch
         if (__instance.hoveredItem == null) return;
 
         string name = __instance.hoveredItem.DisplayName;
+
+        // Converts the item's id from (F)1818 to F_1818  (As brackets aren't supported in fluent matching)
+        // Ref: https://regex101.com/r/5HOvLL/1
+        string strippedQualifiedItemId = Regex.Replace(__instance.hoveredItem.QualifiedItemId, @"\(([A-Za-z]+)\)([0-9]+)", @"$1_$2");
+        string specialName = Translator.Instance.Translate("menu-shop-special_items",
+                tokens: new {item_id = strippedQualifiedItemId},
+                translationCategory: TranslationCategory.Menu);
+#if DEBUG
+        Log.Debug($"Hovered Item: {name} [id={__instance.hoveredItem.QualifiedItemId}] [stripped_id={strippedQualifiedItemId}] [special_name={specialName}]");
+#endif
+        if (specialName != "-9999")
+        {
+            name = specialName;
+        }
+
         string price = __instance.hoverPrice <= 0 ? ""
             : Translator.Instance.Translate("menu-shop-buy_price_info", new { price = __instance.hoverPrice }, TranslationCategory.Menu);
         string description = __instance.hoveredItem.IsRecipe

--- a/stardew-access/Patches/MenuWithInventoryPatches/ShopMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ShopMenuPatch.cs
@@ -86,22 +86,7 @@ internal class ShopMenuPatch : IPatch
     {
         if (__instance.hoveredItem == null) return;
 
-        string name = __instance.hoveredItem.DisplayName;
-
-        // Converts the item's id from (F)1818 to F_1818  (As brackets aren't supported in fluent matching)
-        // Ref: https://regex101.com/r/5HOvLL/1
-        string strippedQualifiedItemId = Regex.Replace(__instance.hoveredItem.QualifiedItemId, @"\(([A-Za-z]+)\)([0-9]+)", @"$1_$2");
-        string specialName = Translator.Instance.Translate("menu-shop-special_items",
-                tokens: new {item_id = strippedQualifiedItemId},
-                translationCategory: TranslationCategory.Menu);
-#if DEBUG
-        Log.Debug($"Hovered Item: {name} [id={__instance.hoveredItem.QualifiedItemId}] [stripped_id={strippedQualifiedItemId}] [special_name={specialName}]");
-#endif
-        if (specialName != "-9999")
-        {
-            name = specialName;
-        }
-
+        string name = InventoryUtils.GetNameOfItem(__instance.hoveredItem.DisplayName, __instance.hoveredItem.QualifiedItemId);
         string price = __instance.hoverPrice <= 0 ? ""
             : Translator.Instance.Translate("menu-shop-buy_price_info", new { price = __instance.hoverPrice }, TranslationCategory.Menu);
         string description = __instance.hoveredItem.IsRecipe

--- a/stardew-access/Utils/DynamicTiles.cs
+++ b/stardew-access/Utils/DynamicTiles.cs
@@ -498,6 +498,11 @@ public class DynamicTiles
 
             return (mailboxName, mailboxCategory);
         }
+        else if ((farm.GetMainFarmHouse().tileX.Value + 1 == x || farm.GetMainFarmHouse().tileX.Value + 2 == x) && farm.GetMainFarmHouse().tileY.Value + 2 == y)
+        {
+            bool flag = !Game1.player.hasOrWillReceiveMail("TH_LumberPile") && Game1.player.hasOrWillReceiveMail("TH_SandDragon");
+            return ("dynamic_tile-farm-lumber_pile", flag ? CATEGORY.Quest : CATEGORY.Decor);
+        }
         else if (building is not null) // Check if there is a building at the current position
         {
             return GetBuildingInfo(building, x, y, lessInfo);

--- a/stardew-access/Utils/InventoryUtils.cs
+++ b/stardew-access/Utils/InventoryUtils.cs
@@ -5,6 +5,7 @@ using StardewValley.Buffs;
 using StardewValley.Tools;
 using StardewValley.TokenizableStrings;
 using StardewValley.Objects;
+using System.Text.RegularExpressions;
 
 namespace stardew_access.Utils;
 
@@ -160,7 +161,43 @@ internal static class InventoryUtils
 
         return toReturn;
     }
-    internal static string GetPluralNameOfItem(Item item) => GetPluralNameOfItem(item.DisplayName, item.Stack);
+
+    /// <summary>
+    /// Returns the in-game name of the item or the custom name if defined.
+    /// </summary>
+    /// <param name="item">The item to get the name of.</param>
+    internal static string GetNameOfItem(Item item) => GetNameOfItem(item.DisplayName, item.QualifiedItemId);
+
+    /// <summary>
+    /// Returns the in-game name of the item or the custom name if defined.
+    /// </summary>
+    /// <param name="qualifiedItemId">The QualifiedItemId of the item to get the name of.</param>
+    internal static string GetNameOfItem(string qualifiedItemId) => GetNameOfItem(ItemRegistry.GetData(qualifiedItemId).DisplayName, qualifiedItemId);
+
+    /// <summary>
+    /// Returns the in-game name of the item or the custom name if defined.
+    /// </summary>
+    /// <param name="displayName">The in-game/default name of the item.</param>
+    /// <param name="qualifiedItemId">The qualifiedItemId of the item to be used for checking for custom name.</param>
+    internal static string GetNameOfItem(string displayName, string qualifiedItemId)
+    {
+        // Converts the item's id from (F)1818 to F_1818  (As brackets aren't supported in fluent matching)
+        // Ref: https://regex101.com/r/pppCfU/1
+        string strippedQualifiedItemId = Regex.Replace(qualifiedItemId, @"\(([A-Za-z0-9]+)\)([A-Za-z0-9]+)", @"$1_$2");
+        string specialName = Translator.Instance.Translate("inventory_util-special_items-name",
+                tokens: new {item_id = strippedQualifiedItemId});
+#if DEBUG
+        Log.Verbose($"Item: {displayName} [id={qualifiedItemId}] [stripped_id={strippedQualifiedItemId}] [special_name={specialName}]");
+#endif
+        if (specialName != "-9999")
+        {
+            displayName = specialName;
+        }
+
+        return displayName;
+    }
+
+    internal static string GetPluralNameOfItem(Item item) => GetPluralNameOfItem(GetNameOfItem(item), item.Stack);
 
     internal static string GetPluralNameOfItem(string itemName, int itemCount)
     {

--- a/stardew-access/assets/TileData/tiles.json
+++ b/stardew-access/assets/TileData/tiles.json
@@ -759,15 +759,6 @@
       "Category": "interactables"
     }
   ],
-  "Farm": [
-    {
-      "NameOrTranslationKey": "static_tile-farm-lumber_pile",
-      "X": [60, 61],
-      "Y": [14],
-      "Category": "decor",
-      "Conditions": ["HasQuest:5"]
-    }
-  ],
   "FarmHouse": [
     {
       "NameOrTranslationKey": "static_tile-farmhouse-cellar_door",

--- a/stardew-access/i18n/en.ftl
+++ b/stardew-access/i18n/en.ftl
@@ -491,6 +491,28 @@ direction-current_tile = Current tile
 
 inventory_util-empty_slot = Empty Slot
 
+# Primarily used to distinguish items with same name, like Jungle Decals or Ceiling Leaves purchased in Luau
+inventory_util-special_items-name = {$item_id ->
+    [F_2627] Jungle Decal (luau) 1
+    [F_2628] Jungle Decal (luau) 2
+    [F_2629] Jungle Decal (luau) 3
+    [F_2630] Jungle Decal (luau) 4
+    [F_1817] Ceiling Leaves (luau) 1
+    [F_1818] Ceiling Leaves (luau) 2
+    [F_1819] Ceiling Leaves (luau) 3
+    [F_1820] Ceiling Leaves (flower dance) 1
+    [F_1821] Ceiling Leaves (flower fance) 2
+    [BC_192] Seasonal Plant (flower dance) 1
+    [BC_204] Seasonal Plant (flower dance) 2
+    [BC_184] Seasonal Plant (egg) 1
+    [BC_188] Seasonal Plant (egg) 2
+    [F_1687] Cloud Decal (moonlight) 1
+    [F_1692] Cloud Decal (moonlight) 2
+    [F_2635] Log Panel (winter star) 1
+    [F_2636] Log Panel (winter star) 2
+    *[other] -9999
+  }
+
 common-unknown = Unknown
 
 # The $name will be in the respective language i.e., it will be in french for french translation and so on. So use the language specific name in the square brackets except for the one with '*', that can have any value. Variants with '*' are marked as default.

--- a/stardew-access/i18n/en.ftl
+++ b/stardew-access/i18n/en.ftl
@@ -204,6 +204,8 @@ dynamic_tile-mastery_cave-pedestal = {$has_hat ->
     [0] Empty Pedestal
     *[1] Pedestal with a Hat
   }
+dynamic_tile-farm-lumber_pile = Lumber Pile
+
 
 ## Interactable Tiles
 

--- a/stardew-access/i18n/menu.en.ftl
+++ b/stardew-access/i18n/menu.en.ftl
@@ -316,26 +316,6 @@ menu-item_grab-chest_colors =
 menu-shop-buy_price_info = Buy price: {$price}g
 menu-shop-recipe_ingredients_info = Ingredients: {$ingredients_list}
 menu-shop-pet_license-suffix = {$content} license
-menu-shop-special_items = {$item_id ->
-    [F_2627] Jungle Decal (luau) 1
-    [F_2628] Jungle Decal (luau) 2
-    [F_2629] Jungle Decal (luau) 3
-    [F_2630] Jungle Decal (luau) 4
-    [F_1817] Ceiling Leaves (luau) 1
-    [F_1818] Ceiling Leaves (luau) 2
-    [F_1819] Ceiling Leaves (luau) 3
-    [F_1820] Ceiling Leaves (flower dance) 1
-    [F_1821] Ceiling Leaves (flower fance) 2
-    [BC_192] Seasonal Plant (flower dance) 1
-    [BC_204] Seasonal Plant (flower dance) 2
-    [BC_184] Seasonal Plant (egg) 1
-    [BC_188] Seasonal Plant (egg) 2
-    [F_1687] Cloud Decal (moonlight) 1
-    [F_1692] Cloud Decal (moonlight) 2
-    [F_2635] Log Panel (winter star) 1
-    [F_2636] Log Panel (winter star) 2
-    *[other] -9999
-  }
 
 ### Tailoring Menu
 

--- a/stardew-access/i18n/menu.en.ftl
+++ b/stardew-access/i18n/menu.en.ftl
@@ -316,6 +316,26 @@ menu-item_grab-chest_colors =
 menu-shop-buy_price_info = Buy price: {$price}g
 menu-shop-recipe_ingredients_info = Ingredients: {$ingredients_list}
 menu-shop-pet_license-suffix = {$content} license
+menu-shop-special_items = {$item_id ->
+    [F_2627] Jungle Decal (luau) 1
+    [F_2628] Jungle Decal (luau) 2
+    [F_2629] Jungle Decal (luau) 3
+    [F_2630] Jungle Decal (luau) 4
+    [F_1817] Ceiling Leaves (luau) 1
+    [F_1818] Ceiling Leaves (luau) 2
+    [F_1819] Ceiling Leaves (luau) 3
+    [F_1820] Ceiling Leaves (flower dance) 1
+    [F_1821] Ceiling Leaves (flower fance) 2
+    [BC_192] Seasonal Plant (flower dance) 1
+    [BC_204] Seasonal Plant (flower dance) 2
+    [BC_184] Seasonal Plant (egg) 1
+    [BC_188] Seasonal Plant (egg) 2
+    [F_1687] Cloud Decal (moonlight) 1
+    [F_1692] Cloud Decal (moonlight) 2
+    [F_2635] Log Panel (winter star) 1
+    [F_2636] Log Panel (winter star) 2
+    *[other] -9999
+  }
 
 ### Tailoring Menu
 

--- a/stardew-access/i18n/static_tiles.en.ftl
+++ b/stardew-access/i18n/static_tiles.en.ftl
@@ -159,10 +159,6 @@ static_tile-elliott_house-piano_key_2 = Piano Key 2
 static_tile-elliott_house-piano_key_3 = Piano Key 3
 static_tile-elliott_house-piano_key_4 = Piano Key 4
 
-# Farm
-
-static_tile-farm-lumber_pile = Lumber Pile
-
 # FarmHouse
 
 static_tile-farmhouse-cellar_door = cellar


### PR DESCRIPTION
[//]: # (A few things to note:)
[//]: # (1. The changelogs will be automatically added to `docs/changelogs/latest.md` by the fast-forward workflow)
[//]: # (2. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (3. Do not change the heading names and/or the heading levels)
[//]: # (4. Remove the unwanted changelog sections)

## Changelog

### Feature Updates

- Added custom names support for items. This can be used to have separate names for items with same names (like for jungle decals purchasable in Luau). At the moment the scope is only at the inventory level or wherever InventoryUtils is used to get the plural form of a name.

### Translation Changes

- New(en.ftl): `dynamic_tile-farm-lumber_pile` with english value `Lumber Pile`.
- Removed(static_tiles.en.ftl): `static_tile-farm-lumber_pile`.
- New(en.ftl): `inventory_util-special_items-name` with placeholder values at the moment.

### Tile Tracker Changes

- Detect lumber pile dynamically.

