### PR TITLE
Various QOL changes and bug fixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,10 +15,10 @@ You can edit the config with any text editor of your choice. It is **strongly** 
 - [Object Tracker Configs](#object-tracker-configs)
 - [Radar Configs](#radar-configs)
 - [Menu Keys Configs](#menu-keys-configs)
-    - [Common Keys](#common-keys)
-    - [Character Creation Menu (New Game Menu) Keys](#character-creation-menu-new-game-menu-keys)
-    - [Junimo Note or Community Center Menu Keys](#junimo-note-or-community-center-menu-keys)
-    - [Chat Menu Configs](#chat-menu-configs)
+  - [Common Keys](#common-keys)
+  - [Character Creation Menu (New Game Menu) Keys](#character-creation-menu-new-game-menu-keys)
+  - [Junimo Note or Community Center Menu Keys](#junimo-note-or-community-center-menu-keys)
+  - [Chat Menu Configs](#chat-menu-configs)
 - [Fishing Mini-Game Configs](#fishing-mini-game-configs)
 - [Narration & Verbosity Configs](#narration--verbosity-configs)
 - [miscellaneous Configs](#miscellaneous-configs)
@@ -34,15 +34,15 @@ Once you have found the Stardew Valley installation directory, navigate to the f
 `%StardewValleyDir%` represents your Stardew Valley installation path. Below are the most common directories where Stardew Valley is installed:
 
 - Windows
-    - Steam: `C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley`
-    - Xbox App: `C:\Program Files\ModifiableWindowsApps\Stardew Valley`
-    - GOG: `C:\Program Files (x86)\GOG Galaxy\Games\Stardew Valley`
+  - Steam: `C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley`
+  - Xbox App: `C:\Program Files\ModifiableWindowsApps\Stardew Valley`
+  - GOG: `C:\Program Files (x86)\GOG Galaxy\Games\Stardew Valley`
 - Mac OS
-    - Steam: `~/Library/Application Support/Steam/SteamApps/common/Stardew Valley/Contents/MacOS`
-    - GOG: `/Applications/Stardew Valley.app/Contents/MacOS`
+  - Steam: `~/Library/Application Support/Steam/SteamApps/common/Stardew Valley/Contents/MacOS`
+  - GOG: `/Applications/Stardew Valley.app/Contents/MacOS`
 - Linux
-    - GOG: `~/GOGGames/StardewValley/game`
-    - Steam: `~/.local/share/Steam/steamapps/common/Stardew Valley`
+  - GOG: `~/GOGGames/StardewValley/game`
+  - Steam: `~/.local/share/Steam/steamapps/common/Stardew Valley`
 
 ## More Info About JSON:
 
@@ -58,12 +58,12 @@ Once you have found the Stardew Valley installation directory, navigate to the f
 - [TextEdit – Mac OS, iOS](https://apps.apple.com/us/app/textedit/id1070883678)
 - [nano – Linux](https://www.nano-editor.org- [Json Editor Online - Web](https://jsoneditoronline.org/)
 
-For a full list of key names,  refer to the [Key Bindings List](https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Button_codes).
+For a full list of key names, refer to the [Key Bindings List](https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Button_codes).
 
 ## Mouse Sim Keys Config
 
 | Name                   | Default Value       | Description                                 |
-|------------------------|---------------------|---------------------------------------------|
+| ---------------------- | ------------------- | ------------------------------------------- |
 | LeftClickMainKey       | LeftControl + Enter | Primary key to simulate mouse left click    |
 | RightClickMainKey      | LeftShift + Enter   | Primary key to simulate mouse right click   |
 | LeftClickAlternateKey  | OemOpenBrackets     | Secondary key to simulate mouse left click  |
@@ -71,82 +71,83 @@ For a full list of key names,  refer to the [Key Bindings List](https://stardewv
 
 ## Read Tile Configs
 
-| Name                     | Default Value | Description                                             |
-|--------------------------|---------------|---------------------------------------------------------|
-| ReadTile                 | true          | Toggle `Read Tile` feature                             |
-| ReadTileKey              | J             | Speak the contents of the tile the player is facing  |
-| ReadTileDebug | false | Sets whether extra debug info is included when reading tile info |
-| ReadStandingTileKey      | LeftAlt + J   | speak the contents of the tile player is standing on |
-| ReadFlooring             | false         | toggle reading floorings                               |
-| WateredToggle            | true          | toggle speaking watered or unwatered for crops         |
-| ReadTileIndexes          | false         | toggle speaking tile indexes with other info           |
-| ReadHoedDirtInMineShafts | false         | toggle speaking hoed dirt (soil) in mine shafts        |
+| Name                       | Default Value | Description                                                                                       |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------- |
+| ReadTile                   | true          | Toggle `Read Tile` feature                                                                        |
+| ReadTileKey                | J             | Speak the contents of the tile the player is facing                                               |
+| ReadTileDebug              | false         | Sets whether extra debug info is included when reading tile info                                  |
+| ReadStandingTileKey        | LeftAlt + J   | Speak the contents of the tile player is standing on                                              |
+| ReadFlooring               | false         | Toggle reading floorings                                                                          |
+| DisableDescriptiveFlooring | false         | Toggle reading descriptive names for flooring or generice ones (pathway/flooring/stepping stone). |
+| WateredToggle              | true          | Toggle speaking watered or unwatered for crops                                                    |
+| ReadTileIndexes            | false         | Toggle speaking tile indexes with other info                                                      |
+| ReadHoedDirtInMineShafts   | false         | Toggle speaking hoed dirt (soil) in mine shafts                                                   |
 
 ## Tile Viewer Configs
 
-| Name                              | Default Value       | Description                                                                                                 |
-|-----------------------------------|---------------------|-------------------------------------------------------------------------------------------------------------|
-| ToggleRelativeCursorLockKey       | L                   | Toggles relative cursor lock                      |
-| AutoWalkToTileKey                 | LeftControl + Enter | Auto walk to focused tile                                                                                       |
-| OpenTileInfoMenuKey               | LeftShift + Enter   | Opens the Tile Info menu for the focused tile                                                               |
-| TileCursorUpKey                   | Up                  | Move the tile cursor one tile up                                                                                 |
-| TileCursorRightKey                | Right               | Move the tile cursor one tile right                                                                              |
-| TileCursorDownKey                 | Down                | Move the tile cursor one tile down                                                                               |
-| TileCursorLeftKey                 | Left                | Move the tile cursor one tile left                                                                               |
-| TileCursorPreciseUpKey            | LeftShift + Up      | Move the tile cursor up by a specified pixel value                                                         |
-| TileCursorPreciseRightKey         | LeftShift + Right   | Move the tile cursor right by a specified pixel value                                                      |
-| TileCursorPreciseDownKey          | LeftShift + Down    | Move the tile cursor down by a specified pixel value                                                       |
-| TileCursorPreciseLeftKey          | LeftShift + Left    | Move the tile cursor left by a specified pixel value                                                       |
-| LimitTileCursorToScreen           | false               | Toggles the ability to move the tile cursor beyond the portion of the map that is visible on screen                                                  |
-| TileCursorPreciseMovementDistance | 8                   | Specifies how many pixels the cursor should move when using precision tile cursor movement |
+| Name                              | Default Value       | Description                                                                                         |
+| --------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------- |
+| ToggleRelativeCursorLockKey       | L                   | Toggles relative cursor lock                                                                        |
+| AutoWalkToTileKey                 | LeftControl + Enter | Auto walk to focused tile                                                                           |
+| OpenTileInfoMenuKey               | LeftShift + Enter   | Opens the Tile Info menu for the focused tile                                                       |
+| TileCursorUpKey                   | Up                  | Move the tile cursor one tile up                                                                    |
+| TileCursorRightKey                | Right               | Move the tile cursor one tile right                                                                 |
+| TileCursorDownKey                 | Down                | Move the tile cursor one tile down                                                                  |
+| TileCursorLeftKey                 | Left                | Move the tile cursor one tile left                                                                  |
+| TileCursorPreciseUpKey            | LeftShift + Up      | Move the tile cursor up by a specified pixel value                                                  |
+| TileCursorPreciseRightKey         | LeftShift + Right   | Move the tile cursor right by a specified pixel value                                               |
+| TileCursorPreciseDownKey          | LeftShift + Down    | Move the tile cursor down by a specified pixel value                                                |
+| TileCursorPreciseLeftKey          | LeftShift + Left    | Move the tile cursor left by a specified pixel value                                                |
+| LimitTileCursorToScreen           | false               | Toggles the ability to move the tile cursor beyond the portion of the map that is visible on screen |
+| TileCursorPreciseMovementDistance | 8                   | Specifies how many pixels the cursor should move when using precision tile cursor movement          |
 
 ## Grid Movement Configs
 
-| Name                                  | Default Value | Description                                         |
-|---------------------------------------|---------------|-----------------------------------------------------|
-| GridMovementActive                    | true          | Enable or disable grid movement            |
-| ToggleGridMovementKey                 | I             | Toggle grid movement                               |
-| GridMovementOverrideKey               | LeftControl   | Disable Grid Movement while held                    |
-| GridMovementSpeed                     | 100           | Player movement speed (percentage)              |
-| GridMovementTilesPerStep              | 1             | Tiles moved per step                               |
+| Name                                  | Default Value | Description                                          |
+| ------------------------------------- | ------------- | ---------------------------------------------------- |
+| GridMovementActive                    | true          | Enable or disable grid movement                      |
+| ToggleGridMovementKey                 | I             | Toggle grid movement                                 |
+| GridMovementOverrideKey               | LeftControl   | Disable Grid Movement while held                     |
+| GridMovementSpeed                     | 100           | Player movement speed (percentage)                   |
+| GridMovementTilesPerStep              | 1             | Tiles moved per step                                 |
 | GridMovementDelayAfterDirectionChange | 250           | Movement delay after changing the player's direction |
 
 ## Object Tracker Configs
 
-| Name                             | Default Value          | Description                                                   |
-|----------------------------------|------------------------|---------------------------------------------------------------|
-| OTCycleUpCategory                | LeftControl + PageUp   | Cycle Up Category                                             |
-| OTCycleDownCategory              | LeftControl + PageDown | Cycle Down Category                                           |
-| OTCycleUpObject                  | PageUp                 | Cycle Up Object                                               |
-| OTCycleDownObject                | PageDown               | Cycle Down Object                                             |
-| OTMoveToSelectedObject           | LeftControl + Home     | Move to the currently selected object                        |
-| OTReadSelectedObject             | Home                   | Read info about the currently selected object                |
-| OTReadSelectedObjectTileLocation | End                    | Read info about the currently selected objects tile location |
-| OTCancelAutoWalking              | Escape                 | Manually stop Auto Walking                                   |
-| OTSwitchSortingMode              | OemTilde               | Toggle between proximity and alphabetical sorting                      |
-| OTSortByProximity                | true                   | Sets whether proximity sorting mode starts enabled       |
-| OTAutoRefreshing                 | true                   |   Sets whether the object tracker auto-refreshes                                                            |
-| OTWrapLists                      | false                  |      Sets whether object tracker lists wrap around when the first or last item is reached                                                         |
-| OTFavorite1 | LeftAlt + D1, RightAlt + D1 | Set object tracker favorite slot 1 |
-| OTFavorite2 | LeftAlt + D2, RightAlt + D2 | Set object tracker favorite slot 2 |
-| OTFavorite3 | LeftAlt + D3, RightAlt + D3 | Set object tracker favorite slot 3 |
-| OTFavorite4 | LeftAlt + D4, RightAlt + D4 | Set object tracker favorite slot 4 |
-| OTFavorite5 | LeftAlt + D5, RightAlt + D5 | Set object tracker favorite slot 5 |
-| OTFavorite6 | LeftAlt + D16 RightAlt + D6 | Set object tracker favorite slot 6 |
-| OTFavorite7 | LeftAlt + D7, RightAlt + D7 | Set object tracker favorite slot 7 |
-| OTFavorite8 | LeftAlt + D8, RightAlt + D8 | Set object tracker favorite slot 8 |
-| OTFavorite9 | LeftAlt + D9, RightAlt + D9 | Set object tracker favorite slot 9 |
-| OTFavorite10 | LeftAlt + D0, RightAlt + D0 | Set object tracker favorite slot 10 |
-| OTFavoriteDecreaseStack | LeftAlt + OemMinus, RightAlt + OemMinus | Browse the previous stack of object tracker favorites |
-| OTFavoriteIncreaseStack | LeftAlt + OemPlus, RightAlt + OemPlus | Next stack of object tracker favorites |
-| OTFavoriteSaveCoordinatesToggle | LeftAlt + OemTilde, RightAlt + OemTilde | Toggle the ability to save coordinates to object tracker favorites |
-| OTFavoriteSaveDefault | LeftAlt + Back, RightAlt + Back | todo |
+| Name                             | Default Value                           | Description                                                                          |
+| -------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
+| OTCycleUpCategory                | LeftControl + PageUp                    | Cycle Up Category                                                                    |
+| OTCycleDownCategory              | LeftControl + PageDown                  | Cycle Down Category                                                                  |
+| OTCycleUpObject                  | PageUp                                  | Cycle Up Object                                                                      |
+| OTCycleDownObject                | PageDown                                | Cycle Down Object                                                                    |
+| OTMoveToSelectedObject           | LeftControl + Home                      | Move to the currently selected object                                                |
+| OTReadSelectedObject             | Home                                    | Read info about the currently selected object                                        |
+| OTReadSelectedObjectTileLocation | End                                     | Read info about the currently selected objects tile location                         |
+| OTCancelAutoWalking              | Escape                                  | Manually stop Auto Walking                                                           |
+| OTSwitchSortingMode              | OemTilde                                | Toggle between proximity and alphabetical sorting                                    |
+| OTSortByProximity                | true                                    | Sets whether proximity sorting mode starts enabled                                   |
+| OTAutoRefreshing                 | true                                    | Sets whether the object tracker auto-refreshes                                       |
+| OTWrapLists                      | false                                   | Sets whether object tracker lists wrap around when the first or last item is reached |
+| OTFavorite1                      | LeftAlt + D1, RightAlt + D1             | Set object tracker favorite slot 1                                                   |
+| OTFavorite2                      | LeftAlt + D2, RightAlt + D2             | Set object tracker favorite slot 2                                                   |
+| OTFavorite3                      | LeftAlt + D3, RightAlt + D3             | Set object tracker favorite slot 3                                                   |
+| OTFavorite4                      | LeftAlt + D4, RightAlt + D4             | Set object tracker favorite slot 4                                                   |
+| OTFavorite5                      | LeftAlt + D5, RightAlt + D5             | Set object tracker favorite slot 5                                                   |
+| OTFavorite6                      | LeftAlt + D16 RightAlt + D6             | Set object tracker favorite slot 6                                                   |
+| OTFavorite7                      | LeftAlt + D7, RightAlt + D7             | Set object tracker favorite slot 7                                                   |
+| OTFavorite8                      | LeftAlt + D8, RightAlt + D8             | Set object tracker favorite slot 8                                                   |
+| OTFavorite9                      | LeftAlt + D9, RightAlt + D9             | Set object tracker favorite slot 9                                                   |
+| OTFavorite10                     | LeftAlt + D0, RightAlt + D0             | Set object tracker favorite slot 10                                                  |
+| OTFavoriteDecreaseStack          | LeftAlt + OemMinus, RightAlt + OemMinus | Browse the previous stack of object tracker favorites                                |
+| OTFavoriteIncreaseStack          | LeftAlt + OemPlus, RightAlt + OemPlus   | Next stack of object tracker favorites                                               |
+| OTFavoriteSaveCoordinatesToggle  | LeftAlt + OemTilde, RightAlt + OemTilde | Toggle the ability to save coordinates to object tracker favorites                   |
+| OTFavoriteSaveDefault            | LeftAlt + Back, RightAlt + Back         | todo                                                                                 |
 
 ## Radar Configs
 
 | Name             | Default Value | Description                                |
-|------------------|---------------|--------------------------------------------|
-| Radar            | false         | Toggle Radar                       |
+| ---------------- | ------------- | ------------------------------------------ |
+| Radar            | false         | Toggle Radar                               |
 | RadarStereoSound | true          | Set whether stereo sound is used for radar |
 
 ## Menu Keys Configs
@@ -157,29 +158,29 @@ For a full list of key names,  refer to the [Key Bindings List](https://stardewv
 
 ### Common Keys
 
-| Name                                 | Default Value | Description                                                                                   |
-|--------------------------------------|---------------|-----------------------------------------------------------------------------------------------|
-| PrimaryInfoKey                       | C             | Used to speak additional info on many menus. More info available here: [Primary Info Key](keybindings.md#primary-info-key)   |
-| SnapToFirstInventorySlotKey          | I             | Snaps to the first slot in the player's inventory      |
-| SnapToFirstSecondaryInventorySlotKey | LeftShift + I | Snaps to the first slot in the secondary inventory, such as a chest  |
-| CraftingMenuCycleThroughRecipesKey   | C             | Cycle through available recipes in the crafting menu                                                   |
+| Name                                 | Default Value | Description                                                                                                                |
+| ------------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| PrimaryInfoKey                       | C             | Used to speak additional info on many menus. More info available here: [Primary Info Key](keybindings.md#primary-info-key) |
+| SnapToFirstInventorySlotKey          | I             | Snaps to the first slot in the player's inventory                                                                          |
+| SnapToFirstSecondaryInventorySlotKey | LeftShift + I | Snaps to the first slot in the secondary inventory, such as a chest                                                        |
+| CraftingMenuCycleThroughRecipesKey   | C             | Cycle through available recipes in the crafting menu                                                                       |
 
 ### Character Creation Menu (New Game Menu) Keys
 
-| Name                                        | Default Value       | Description                                |
-|---------------------------------------------|---------------------|--------------------------------------------|
-| CharacterCreationMenuNextKey                | Right               | Go to next element                         |
-| CharacterCreationMenuPreviousKey            | Left                | Go to previous element                     |
+| Name                                        | Default Value       | Description                                  |
+| ------------------------------------------- | ------------------- | -------------------------------------------- |
+| CharacterCreationMenuNextKey                | Right               | Go to next element                           |
+| CharacterCreationMenuPreviousKey            | Left                | Go to previous element                       |
 | CharacterCreationMenuDesignToggleKey        | LeftControl + Space | Toggle displaying character creation options |
-| CharacterCreationMenuSliderIncreaseKey      | Up                  | Increase the slider value by 1             |
-| CharacterCreationMenuSliderLargeIncreaseKey | PageUp              | Increase the slider value by 10            |
-| CharacterCreationMenuSliderDecreaseKey      | Down                | Decrease the slider value by 1             |
-| CharacterCreationMenuSliderLargeDecreaseKey | PageDown            | Decrease the slider value by 10            |
+| CharacterCreationMenuSliderIncreaseKey      | Up                  | Increase the slider value by 1               |
+| CharacterCreationMenuSliderLargeIncreaseKey | PageUp              | Increase the slider value by 10              |
+| CharacterCreationMenuSliderDecreaseKey      | Down                | Decrease the slider value by 1               |
+| CharacterCreationMenuSliderLargeDecreaseKey | PageDown            | Decrease the slider value by 10              |
 
 ### Junimo Note or Community Center Menu Keys
 
 | Name                              | Default Value | Description                                                  |
-|-----------------------------------|---------------|--------------------------------------------------------------|
+| --------------------------------- | ------------- | ------------------------------------------------------------ |
 | BundleMenuIngredientsKey          | I             | Cycle through the ingredients in the current selected bundle |
 | BundleMenuInventoryItemsKey       | C             | Cycle through the items in the player's inventory            |
 | BundleMenuPurchaseButtonKey       | P             | Move the mouse cursor to purchase button                     |
@@ -189,54 +190,54 @@ For a full list of key names,  refer to the [Key Bindings List](https://stardewv
 ### Chat Menu Configs
 
 | Name                | Default Value | Description                |
-|---------------------|---------------|----------------------------|
+| ------------------- | ------------- | -------------------------- |
 | ChatMenuNextKey     | PageUp        | Read previous chat message |
 | ChatMenuPreviousKey | PageDown      | Read next chat message     |
 
 ## Fishing Mini-Game Configs
 
 | Name                     | Default Value | Description                                                                                                                                                                                                                                                                                                            |
-|--------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | MaximumFishingDifficulty | 999           | Every fish have a difficulty value which varies from around 0 to 150. You can use this to limit the maximum difficulty any fish can have.                                                                                                                                                                              |
 | FixFishingMotionType     | 999           | You can fix what motion type every fish has, by default every fish has a fixed motion type like for squid it's sinker, walleye it's smooth, etc. You can use a value between 0 to 4 to fix the motion. 0 indicates mixed motion type, 1 indicates art, 2 indicates smooth, 3 indicates sinker and 4 indicates floater. |
 
 ## Narration & Verbosity Configs
 
-| Name                       | Default Value | Description                                                                  |
-|----------------------------|---------------|------------------------------------------------------------------------------|
-| RepeatLastTextKey | LeftAlt + Space, RightAlt + Space | Repeat the last phrase that was narrated |
-| HealthNStaminaKey          | H             | Narrate health and stamina.                                                  |
-| HealthNStaminaInPercentage | true          | Whether to speak health and stamina in percentage or the actual value        |
-| List PositionKey           | K             | Narrate player position.                                                     |
-| List LocationKey           | LeftAlt + K   | Narrate current location name.                                               |
-| List MoneyKey              | R             | Narrate the money the player has currently.                                  |
-| List TimeNSeasonKey        | Q             | Narrate the time of day, day and date and season                             |
-| Use24HourFormat | false | Switch time narration between 12-hour and 24-hour |
-| VerboseCoordinates         | true          | Whether to speak 'X:' and 'Y:' along with co-ordinates or not                |
-| SnapMouse                  | true          | Toggles the snap mouse feature                                               |
-| Warning                    | true          | Toggles the warnings feature                                                 |
-| TTS                        | true          | Toggles the screen reader/tts.                                               |
-| TrackDroppedItems          | true          | Toggles detecting the dropped items.                                         |
-| DisableInventoryVerbosity  | false         | If enabled, does not speaks 'not usable here' and 'donatable' in inventories |
-| DisableBushVerbosity       | false         | If enabled, does not speak bush type or size; only harvestable.              |
-| MacSpeechRate              | 220           | Sets speech rate for the Mac TTS.                                            |
-| DisableDescriptiveDebris | false | Sets whether items such as sticks and stones have more detailed descriptions |
-| DisableColorfulSlime | false | Sets whether slime color is read |
-| ExtraColors | false | Sets whether the full list of colors is used for color description. [Full color list in this repository](https://github.com/meodai/color-names) |
-| DisableInventoryFluentPluralization | false | Sets whether inventory items are pluralized when spoken |
+| Name                                | Default Value                     | Description                                                                                                                                     |
+| ----------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| RepeatLastTextKey                   | LeftAlt + Space, RightAlt + Space | Repeat the last phrase that was narrated                                                                                                        |
+| HealthNStaminaKey                   | H                                 | Narrate health and stamina.                                                                                                                     |
+| HealthNStaminaInPercentage          | true                              | Whether to speak health and stamina in percentage or the actual value                                                                           |
+| List PositionKey                    | K                                 | Narrate player position.                                                                                                                        |
+| List LocationKey                    | LeftAlt + K                       | Narrate current location name.                                                                                                                  |
+| List MoneyKey                       | R                                 | Narrate the money the player has currently.                                                                                                     |
+| List TimeNSeasonKey                 | Q                                 | Narrate the time of day, day and date and season                                                                                                |
+| Use24HourFormat                     | false                             | Switch time narration between 12-hour and 24-hour                                                                                               |
+| VerboseCoordinates                  | true                              | Whether to speak 'X:' and 'Y:' along with co-ordinates or not                                                                                   |
+| SnapMouse                           | true                              | Toggles the snap mouse feature                                                                                                                  |
+| Warning                             | true                              | Toggles the warnings feature                                                                                                                    |
+| TTS                                 | true                              | Toggles the screen reader/tts.                                                                                                                  |
+| TrackDroppedItems                   | true                              | Toggles detecting the dropped items.                                                                                                            |
+| DisableInventoryVerbosity           | false                             | If enabled, does not speaks 'not usable here' and 'donatable' in inventories                                                                    |
+| DisableBushVerbosity                | false                             | If enabled, does not speak bush type or size; only harvestable.                                                                                 |
+| MacSpeechRate                       | 220                               | Sets speech rate for the Mac TTS.                                                                                                               |
+| DisableDescriptiveDebris            | false                             | Sets whether items such as sticks and stones have more detailed descriptions                                                                    |
+| DisableColorfulSlime                | false                             | Sets whether slime color is read                                                                                                                |
+| ExtraColors                         | false                             | Sets whether the full list of colors is used for color description. [Full color list in this repository](https://github.com/meodai/color-names) |
+| DisableInventoryFluentPluralization | false                             | Sets whether inventory items are pluralized when spoken                                                                                         |
 
 ## miscellaneous Configs
 
-| Name                       | Default Value | Description                                                                  |
-|----------------------------|---------------|------------------------------------------------------------------------------|
-| YouveGotMailSound | true | Sets playing a sound when there is new mail in your mailbox |
-| EnableCheats | false | Sets whether Stardew Access enables debug mode on startup |
+| Name              | Default Value | Description                                                 |
+| ----------------- | ------------- | ----------------------------------------------------------- |
+| YouveGotMailSound | true          | Sets playing a sound when there is new mail in your mailbox |
+| EnableCheats      | false         | Sets whether Stardew Access enables debug mode on startup   |
 
 ## Default Config
 
-This config is current as of [Beta Release v1.4.0-beta.4](https://github.com/khanshoaib3/stardew-access/releases/tag/v1.6.0-beta.4)
+This config is current as of [Beta Release v1.6.0-beta.4](https://github.com/khanshoaib3/stardew-access/releases/tag/v1.6.0-beta.4)
 
-~~~json
+```json
 {
   "LeftClickMainKey": "LeftControl + Enter",
   "RightClickMainKey": "LeftShift + Enter",
@@ -248,6 +249,7 @@ This config is current as of [Beta Release v1.4.0-beta.4](https://github.com/kha
   "ReadTileKey": "J",
   "ReadStandingTileKey": "LeftAlt + J",
   "ReadFlooring": false,
+  "DisableDescriptiveFlooring": false,
   "WateredToggle": true,
   "ReadTileDebug": false,
   "ReadHoedDirtInMineShafts": false,
@@ -327,6 +329,11 @@ This config is current as of [Beta Release v1.4.0-beta.4](https://github.com/kha
   "SnapMouse": true,
   "Warning": true,
   "TTS": true,
+  "AutoReadCharacterBubbles": true,
+  "AutoReadCharacterDialog": true,
+  "AutoReadQuestionDialog": true,
+  "AutoReadBasicDialog": true,
+  "ManualReadDialogKey": "R",
   "TrackDroppedItems": true,
   "DisableInventoryVerbosity": false,
   "DisableBushVerbosity": false,
@@ -340,7 +347,8 @@ This config is current as of [Beta Release v1.4.0-beta.4](https://github.com/kha
   "MaximumFishingDifficulty": 999,
   "FixFishingMotionType": 999,
   "Use24HourFormat": false
-}~~~
+}
+```
 
 ## Other Pages
 

--- a/stardew-access/Features/TileViewer/TileDataEntryMenu.cs
+++ b/stardew-access/Features/TileViewer/TileDataEntryMenu.cs
@@ -35,7 +35,7 @@ public class TileDataEntryMenu : IClickableMenu
 
     private readonly ClickableTextureComponent _okButton;
     private static readonly string None = Translator.Instance.Translate("menu-tile_data_entry-none", TranslationCategory.Menu);
-    
+
     public TileDataEntryMenu(int tileX, int tileY, AccessibleTile.JsonSerializerFormat? defaultData = null)
         : base(Game1.viewport.Width / 2 - (1175 + borderWidth * 2) / 2,
             Game1.viewport.Height / 2 - (700 + borderWidth * 2) / 2 - 64, 1175 + borderWidth * 2,
@@ -88,7 +88,7 @@ public class TileDataEntryMenu : IClickableMenu
             }
         }
 
-        AddLabel( Translator.Instance.Translate("menu-tile_data_entry-heading_label",
+        AddLabel(Translator.Instance.Translate("menu-tile_data_entry-heading_label",
                 new { tile_x = _tileX, tile_y = _tileY, location_name = Game1.currentLocation.NameOrUniqueName },
                 TranslationCategory.Menu),
             (int)OptionsIdentifiers.HeadingLabel);
@@ -256,7 +256,7 @@ public class TileDataEntryMenu : IClickableMenu
             if (el is OptionsDropDown) continue;
             if (!el.bounds.Contains(x, y)) continue;
             if (el.greyedOut) continue;
-            
+
             el.receiveLeftClick(x, y);
             return;
         }
@@ -311,7 +311,7 @@ public class TileDataEntryMenu : IClickableMenu
                 case (int)OptionsIdentifiers.FarmTypeCheckbox:
                     var farmTypeCheckbox = (optionsElement as OptionsCheckbox)!;
                     if (farmTypeCheckbox.isChecked)
-                        conditions.Add($"Farm:{FarmTypeName(Game1.whichFarm)}");
+                        conditions.Add($"Farm:{FarmTypeId(Game1.whichFarm)}");
                     break;
                 case (int)OptionsIdentifiers.FarmHouseUpgradeLevelDropDown:
                     var farmHouseUpgradeDropDown = (optionsElement as OptionsDropDown)!;
@@ -372,11 +372,11 @@ public class TileDataEntryMenu : IClickableMenu
         {
             if (!el.bounds.Contains(x, y)) continue;
             if (el.greyedOut) continue;
-            
+
             el.leftClickHeld(x, y);
             return;
         }
-        
+
         base.leftClickHeld(x, y);
     }
 
@@ -386,11 +386,11 @@ public class TileDataEntryMenu : IClickableMenu
         {
             if (!el.bounds.Contains(x, y)) continue;
             if (el.greyedOut) continue;
-            
+
             el.leftClickReleased(x, y);
             return;
         }
-        
+
         base.releaseLeftClick(x, y);
     }
 
@@ -398,7 +398,7 @@ public class TileDataEntryMenu : IClickableMenu
     {
         if (TextBoxPatch.IsAnyTextBoxActive) // Suppress any key input if text box is active
             return;
-        
+
         int x = Game1.getMouseX(true), y = Game1.getMouseY(true);
         foreach (var el in _options)
         {
@@ -437,7 +437,7 @@ public class TileDataEntryMenu : IClickableMenu
             MainClass.ScreenReader.TranslateAndSayWithMenuChecker("common-ui-ok_button", true);
             return;
         }
-        
+
         OptionsElementUtils.NarrateOptionsElements(_options);
     }
 
@@ -450,11 +450,11 @@ public class TileDataEntryMenu : IClickableMenu
             el.draw(b, 0, 0);
         }
         _okButton.draw(b);
-        
+
         drawMouse(b);
     }
 
-    private static string FarmTypeName(int whichFarm) => whichFarm switch
+    private static string FarmTypeId(int whichFarm) => whichFarm switch
     {
         0 => "standard",
         1 => "riverland",
@@ -463,18 +463,23 @@ public class TileDataEntryMenu : IClickableMenu
         4 => "wilderness",
         5 => "fourcorners",
         6 => "beach",
+        7 => Game1.whichModFarm.Id,
         _ => ""
     };
 
     private static string FarmTypeDisplayName(int whichFarm) => whichFarm switch
     {
-        0 => Game1.content.LoadString("Strings\\UI:Character_FarmStandard").Split("_")[0],
-        1 => Game1.content.LoadString("Strings\\UI:Character_FarmFishing").Split("_")[0],
-        2 => Game1.content.LoadString("Strings\\UI:Character_FarmForaging").Split("_")[0],
-        3 => Game1.content.LoadString("Strings\\UI:Character_FarmMining").Split("_")[0],
-        4 => Game1.content.LoadString("Strings\\UI:Character_FarmCombat").Split("_")[0],
-        5 => Game1.content.LoadString("Strings\\UI:Character_FarmFourCorners").Split("_")[0],
-        6 => Game1.content.LoadString("Strings\\UI:Character_FarmBeach").Split("_")[0],
+        0 => FarmTypeDisplayName("Strings\\UI:Character_FarmStandard"),
+        1 => FarmTypeDisplayName("Strings\\UI:Character_FarmFishing"),
+        2 => FarmTypeDisplayName("Strings\\UI:Character_FarmForaging"),
+        3 => FarmTypeDisplayName("Strings\\UI:Character_FarmMining"),
+        4 => FarmTypeDisplayName("Strings\\UI:Character_FarmCombat"),
+        5 => FarmTypeDisplayName("Strings\\UI:Character_FarmFourCorners"),
+        6 => FarmTypeDisplayName("Strings\\UI:Character_FarmBeach"),
+        7 => FarmTypeDisplayName(Game1.whichModFarm.TooltipStringPath),
         _ => ""
     };
+
+    private static string FarmTypeDisplayName(string tooltipStringPath)
+        => Game1.content.LoadString(tooltipStringPath).Split("_")[0];
 }

--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -69,6 +69,11 @@ internal class ModConfig
     public Boolean ReadFlooring { get; set; } = false;
 
     /// <summary>
+    /// Toggle reading descriptive names for flooring or generice ones (pathway/flooring/stepping stone).
+    /// </summary>
+    public Boolean DisableDescriptiveFlooring { get; set; } = false;
+
+    /// <summary>
     /// Toggle speaking watered or unwatered for crops.
     /// </summary>
     public Boolean WateredToggle { get; set; } = true;

--- a/stardew-access/Patches/MenuWithInventoryPatches/ForgeMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ForgeMenuPatch.cs
@@ -1,119 +1,123 @@
 using HarmonyLib;
 using Microsoft.Xna.Framework.Graphics;
-using stardew_access.Translation;
 using stardew_access.Utils;
 using StardewValley;
 using StardewValley.Menus;
 
-namespace stardew_access.Patches
+namespace stardew_access.Patches;
+
+internal class ForgeMenuPatch : IPatch
 {
-    internal class ForgeMenuPatch : IPatch
+    public void Apply(Harmony harmony)
     {
-        public void Apply(Harmony harmony)
+        harmony.Patch(
+            original: AccessTools.Method(typeof(ForgeMenu), nameof(ForgeMenu.draw), new Type[] { typeof(SpriteBatch) }),
+            postfix: new HarmonyMethod(typeof(ForgeMenuPatch), nameof(ForgeMenuPatch.DrawPatch))
+        );
+    }
+
+    private static void DrawPatch(ForgeMenu __instance)
+    {
+        try
         {
-            harmony.Patch(
-                original: AccessTools.Method(typeof(ForgeMenu), nameof(ForgeMenu.draw), new Type[] { typeof(SpriteBatch) }),
-                postfix: new HarmonyMethod(typeof(ForgeMenuPatch), nameof(ForgeMenuPatch.DrawPatch))
-            );
+            int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
+
+            if (NarrateHoveredButton(__instance, x, y)) return;
+
+            InventoryUtils.NarrateHoveredSlot(__instance.inventory);
+
+        }
+        catch (System.Exception e)
+        {
+            Log.Error($"An error occurred in forge menu patch:\n{e.Message}\n{e.StackTrace}");
+        }
+    }
+
+    private static bool NarrateHoveredButton(ForgeMenu __instance, int x, int y)
+    {
+        string translationKey = "";
+        object? translationTokens = null;
+        bool isDropItemButton = false;
+
+        if (__instance.leftIngredientSpot != null && __instance.leftIngredientSpot.containsPoint(x, y))
+        {
+            translationKey = "menu-forge-weapon_input_slot";
+            Item? item = __instance.leftIngredientSpot.item;
+            translationTokens = new
+            {
+                is_empty = (item == null) ? 1 : 0,
+                item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item)
+            };
+        }
+        else if (__instance.rightIngredientSpot != null && __instance.rightIngredientSpot.containsPoint(x, y))
+        {
+            translationKey = "menu-forge-gemstone_input_slot";
+            Item? item = __instance.rightIngredientSpot.item;
+            translationTokens = new
+            {
+                is_empty = (item == null) ? 1 : 0,
+                item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item)
+            };
+        }
+        else if (__instance.startTailoringButton != null && __instance.startTailoringButton.containsPoint(x, y))
+        {
+            translationKey = "menu-forge-start_forging_button";
+            translationTokens = new
+            {
+                forge_cost = __instance.IsValidCraft(__instance.leftIngredientSpot?.item, __instance.rightIngredientSpot?.item)
+                    ? __instance.GetForgeCost(__instance.leftIngredientSpot!.item, __instance.rightIngredientSpot!.item)
+                    : 0
+            };
+        }
+        else if (__instance.unforgeButton != null && __instance.unforgeButton.containsPoint(x, y))
+        {
+            translationKey = "menu-forge-unforge_button";
+        }
+        else if (__instance.trashCan != null && __instance.trashCan.containsPoint(x, y))
+        {
+            translationKey = "common-ui-trashcan_button";
+        }
+        else if (__instance.okButton != null && __instance.okButton.containsPoint(x, y))
+        {
+            translationKey = "common-ui-ok_button";
+        }
+        else if (__instance.dropItemInvisibleButton != null && __instance.dropItemInvisibleButton.containsPoint(x, y))
+        {
+            translationKey = "common-ui-drop_item_button";
+            isDropItemButton = true;
+        }
+        else if (__instance.equipmentIcons.Count > 0 && __instance.equipmentIcons[0].containsPoint(x, y))
+        {
+            translationKey = "common-ui-equipment_slots";
+            Item? item = Game1.player.leftRing.Value;
+            translationTokens = new
+            {
+                slot_name = "left_ring",
+                is_empty = (item == null) ? 1 : 0,
+                item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item),
+                item_description = ""
+            };
+        }
+        else if (__instance.equipmentIcons.Count > 0 && __instance.equipmentIcons[1].containsPoint(x, y))
+        {
+            translationKey = "common-ui-equipment_slots";
+            Item? item = Game1.player.rightRing.Value;
+            translationTokens = new
+            {
+                slot_name = "right_ring",
+                is_empty = (item == null) ? 1 : 0,
+                item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item),
+                item_description = ""
+            };
+        }
+        else
+        {
+            return false;
         }
 
-        private static void DrawPatch(ForgeMenu __instance)
-        {
-            try
-            {
-                int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
+        if (MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true, translationTokens))
+            if (isDropItemButton) Game1.playSound("drop_item");
 
-                if (NarrateHoveredButton(__instance, x, y)) return;
-
-                InventoryUtils.NarrateHoveredSlot(__instance.inventory);
-
-            }
-            catch (System.Exception e)
-            {
-                Log.Error($"An error occurred in forge menu patch:\n{e.Message}\n{e.StackTrace}");
-            }
-        }
-
-        private static bool NarrateHoveredButton(ForgeMenu __instance, int x, int y)
-        {
-            string translationKey = "";
-            object? translationTokens = null;
-            bool isDropItemButton = false;
-
-            if (__instance.leftIngredientSpot != null && __instance.leftIngredientSpot.containsPoint(x, y))
-            {
-                translationKey = "menu-forge-weapon_input_slot";
-                Item? item = __instance.leftIngredientSpot.item;
-                translationTokens = new
-                {
-                    is_empty = (item == null) ? 1 : 0,
-                    item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item)
-                };
-            }
-            else if (__instance.rightIngredientSpot != null && __instance.rightIngredientSpot.containsPoint(x, y))
-            {
-                translationKey = "menu-forge-gemstone_input_slot";
-                Item? item = __instance.rightIngredientSpot.item;
-                translationTokens = new
-                {
-                    is_empty = (item == null) ? 1 : 0,
-                    item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item)
-                };
-            }
-            else if (__instance.startTailoringButton != null && __instance.startTailoringButton.containsPoint(x, y))
-            {
-                translationKey = "menu-forge-start_forging_button";
-            }
-            else if (__instance.unforgeButton != null && __instance.unforgeButton.containsPoint(x, y))
-            {
-                translationKey = "menu-forge-unforge_button";
-            }
-            else if (__instance.trashCan != null && __instance.trashCan.containsPoint(x, y))
-            {
-                translationKey = "common-ui-trashcan_button";
-            }
-            else if (__instance.okButton != null && __instance.okButton.containsPoint(x, y))
-            {
-                translationKey = "common-ui-ok_button";
-            }
-            else if (__instance.dropItemInvisibleButton != null && __instance.dropItemInvisibleButton.containsPoint(x, y))
-            {
-                translationKey = "common-ui-drop_item_button";
-                isDropItemButton = true;
-            }
-            else if (__instance.equipmentIcons.Count > 0 && __instance.equipmentIcons[0].containsPoint(x, y))
-            {
-                translationKey = "common-ui-equipment_slots";
-                Item? item = Game1.player.leftRing.Value;
-                translationTokens = new
-                {
-                    slot_name = "left_ring",
-                    is_empty = (item == null) ? 1 : 0,
-                    item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item),
-                    item_description = ""
-                };
-            }
-            else if (__instance.equipmentIcons.Count > 0 && __instance.equipmentIcons[1].containsPoint(x, y))
-            {
-                translationKey = "common-ui-equipment_slots";
-                Item? item = Game1.player.rightRing.Value;
-                translationTokens = new
-                {
-                    slot_name = "right_ring",
-                    is_empty = (item == null) ? 1 : 0,
-                    item_name = (item == null) ? "" : InventoryUtils.GetPluralNameOfItem(item),
-                    item_description = ""
-                };
-            }
-            else
-            {
-                return false;
-            }
-
-            if (MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true, translationTokens))
-                if (isDropItemButton) Game1.playSound("drop_item");
-
-            return true;
-        }
+        return true;
     }
 }

--- a/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
@@ -1,123 +1,115 @@
 using HarmonyLib;
 using Microsoft.Xna.Framework.Graphics;
-using Netcode;
 using stardew_access.Translation;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.SpecialOrders;
 
-namespace stardew_access.Patches
+namespace stardew_access.Patches;
+
+internal class SpecialOrdersBoardPatch : IPatch
 {
-    internal class SpecialOrdersBoardPatch : IPatch
+    public void Apply(Harmony harmony)
     {
-        public void Apply(Harmony harmony)
-        {
-            harmony.Patch(
-                    original: AccessTools.Method(typeof(SpecialOrdersBoard), nameof(SpecialOrdersBoard.draw), new Type[] { typeof(SpriteBatch) }),
-                    postfix: new HarmonyMethod(typeof(SpecialOrdersBoardPatch), nameof(SpecialOrdersBoardPatch.DrawPatch))
-            );
-        }
+        harmony.Patch(
+                original: AccessTools.Method(typeof(SpecialOrdersBoard), nameof(SpecialOrdersBoard.draw), new Type[] { typeof(SpriteBatch) }),
+                postfix: new HarmonyMethod(typeof(SpecialOrdersBoardPatch), nameof(SpecialOrdersBoardPatch.DrawPatch))
+        );
+    }
 
-        private static void DrawPatch(SpecialOrdersBoard __instance)
+    private static void DrawPatch(SpecialOrdersBoard __instance)
+    {
+        try
         {
-            try
+            int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
+
+            if (__instance.acceptLeftQuestButton.visible && __instance.acceptLeftQuestButton.containsPoint(x, y))
             {
-                int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
-
-                if (__instance.acceptLeftQuestButton.visible && __instance.acceptLeftQuestButton.containsPoint(x, y))
+                MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-accept_button", true, new
                 {
-                    MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-accept_button", true, new
-                    {
-                        is_left_quest = 1,
-                        quest_details = GetQuestDetails(__instance.leftOrder)
-                    });
-                    return;
-                }
-
-                if (__instance.acceptRightQuestButton.visible && __instance.acceptRightQuestButton.containsPoint(x, y))
-                {
-                    MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-accept_button", true, new
-                    {
-                        is_left_quest = 0,
-                        quest_details = GetQuestDetails(__instance.rightOrder)
-                    });
-                    return;
-                }
-
-                if (Game1.player.team.acceptedSpecialOrderTypes.Contains(__instance.GetOrderType()))
-                {
-                    if (__instance.leftOrder.questState.Value == SpecialOrderStatus.InProgress)
-                    {
-                        MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_in_progress", true, new
-                        {
-                            quest_details = GetQuestDetails((IsInProgress(__instance.leftOrder, __instance)) ? __instance.leftOrder : __instance.rightOrder)
-                        });
-                    }
-                    return;
-                }
-
-                // FIXME Does not indicate completed status with this logic
-                /*
-                if (Game1.player.team.completedSpecialOrders.ContainsKey(__instance.GetOrderType()))
-                {
-                    if (__instance.leftOrder.questState.Value == SpecialOrder.QuestState.Complete || __instance.rightOrder.questState.Value == SpecialOrder.QuestState.Complete)
-                    {
-                        MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_completed", true, new
-                        {
-                            name = (__instance.leftOrder.questState.Value == SpecialOrder.QuestState.Complete) ? __instance.leftOrder.GetName() : __instance.rightOrder.GetName()
-                        });
-                    }
-                }
-                */
+                    is_left_quest = 1,
+                    quest_details = GetQuestDetails(__instance.leftOrder)
+                });
+                return;
             }
-            catch (Exception e)
+
+            if (__instance.acceptRightQuestButton.visible && __instance.acceptRightQuestButton.containsPoint(x, y))
             {
-                Log.Error($"An error occurred in special orders board patch:\n{e.Message}\n{e.StackTrace}");
+                MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-accept_button", true, new
+                {
+                    is_left_quest = 0,
+                    quest_details = GetQuestDetails(__instance.rightOrder)
+                });
+                return;
+            }
+
+            SpecialOrder inProgress = IsInProgress(__instance.leftOrder, __instance) ? __instance.leftOrder : __instance.rightOrder;
+
+            if (__instance.boardType == "" && Game1.player.team.completedSpecialOrders.Contains(inProgress.questKey.Value))
+            {
+                MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_completed", true, new
+                {
+                    name = inProgress.GetName()
+                });
+                return;
+            }
+
+            if (Game1.player.team.acceptedSpecialOrderTypes.Contains(__instance.GetOrderType()))
+            {
+                MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_in_progress", true, new
+                {
+                    quest_details = GetQuestDetails(inProgress)
+                });
+                return;
             }
         }
-
-        private static string GetQuestDetails(SpecialOrder order) => Translator.Instance.Translate(
-            "menu-special_orders_board-quest_details", new
-            {
-                name = order.GetName(),
-                description = order.GetDescription(),
-                objectives_list = string.Join(", ", order.GetObjectiveDescriptions()),
-                is_timed = order.IsTimedQuest() ? 1 : 0,
-                days = order.GetDaysLeft(),
-                has_money_reward = order.HasMoneyReward() ? 1 : 0,
-                money = order.GetMoneyReward()
-            },
-            TranslationCategory.Menu);
-
-        private static bool IsInProgress(SpecialOrder order, SpecialOrdersBoard __instance)
+        catch (Exception e)
         {
-            bool flag1 = false;
-            bool flag2 = false;
-            foreach (SpecialOrder specialOrder in Game1.player.team.specialOrders)
-            {
-                if (specialOrder.questState.Value == SpecialOrderStatus.InProgress)
-                {
-                    foreach (SpecialOrder availableSpecialOrder in Game1.player.team.availableSpecialOrders)
-                    {
-                        if (!(availableSpecialOrder.orderType.Value != __instance.GetOrderType()) &&
-                            specialOrder.questKey.Value == availableSpecialOrder.questKey.Value)
-                        {
-                            if (order.questKey != specialOrder.questKey)
-                                flag1 = true;
-                            flag2 = true;
-                            break;
-                        }
-                    }
+            Log.Error($"An error occurred in special orders board patch:\n{e.Message}\n{e.StackTrace}");
+        }
+    }
 
-                    if (flag2)
+    private static string GetQuestDetails(SpecialOrder order) => Translator.Instance.Translate(
+        "menu-special_orders_board-quest_details", new
+        {
+            name = order.GetName(),
+            description = order.GetDescription(),
+            objectives_list = string.Join(", ", order.GetObjectiveDescriptions()),
+            is_timed = order.IsTimedQuest() ? 1 : 0,
+            days = order.GetDaysLeft(),
+            has_money_reward = order.HasMoneyReward() ? 1 : 0,
+            money = order.GetMoneyReward()
+        },
+        TranslationCategory.Menu);
+
+    private static bool IsInProgress(SpecialOrder order, SpecialOrdersBoard __instance)
+    {
+        bool flag1 = false;
+        bool flag2 = false;
+        foreach (SpecialOrder specialOrder in Game1.player.team.specialOrders)
+        {
+            if (specialOrder.questState.Value == SpecialOrderStatus.InProgress)
+            {
+                foreach (SpecialOrder availableSpecialOrder in Game1.player.team.availableSpecialOrders)
+                {
+                    if (!(availableSpecialOrder.orderType.Value != __instance.GetOrderType()) &&
+                        specialOrder.questKey.Value == availableSpecialOrder.questKey.Value)
+                    {
+                        if (order.questKey != specialOrder.questKey)
+                            flag1 = true;
+                        flag2 = true;
                         break;
+                    }
                 }
+
+                if (flag2)
+                    break;
             }
-
-            if (!flag2 && Game1.player.team.acceptedSpecialOrderTypes.Contains(__instance.GetOrderType()))
-                flag1 = true;
-
-            return !flag1;
         }
+
+        if (!flag2 && Game1.player.team.acceptedSpecialOrderTypes.Contains(__instance.GetOrderType()))
+            flag1 = true;
+
+        return flag1;
     }
 }

--- a/stardew-access/Utils/InventoryUtils.cs
+++ b/stardew-access/Utils/InventoryUtils.cs
@@ -185,7 +185,7 @@ internal static class InventoryUtils
         // Ref: https://regex101.com/r/pppCfU/1
         string strippedQualifiedItemId = Regex.Replace(qualifiedItemId, @"\(([A-Za-z0-9]+)\)([A-Za-z0-9]+)", @"$1_$2");
         string specialName = Translator.Instance.Translate("inventory_util-special_items-name",
-                tokens: new {item_id = strippedQualifiedItemId});
+                tokens: new { item_id = strippedQualifiedItemId });
 #if DEBUG
         Log.Verbose($"Item: {displayName} [id={qualifiedItemId}] [stripped_id={strippedQualifiedItemId}] [special_name={specialName}]");
 #endif
@@ -242,6 +242,16 @@ internal static class InventoryUtils
         var enchantList = (item is MeleeWeapon) ? (item as MeleeWeapon)!.enchantments : (item as Tool)!.enchantments;
         foreach (var enchantment in enchantList)
         {
+            if (enchantment is StardewValley.Enchantments.GalaxySoulEnchantment galaxySoulEnchantment)
+            {
+                int percentageCompleted = (galaxySoulEnchantment.GetLevel() * 100) / galaxySoulEnchantment.GetMaximumLevel();
+                enchantNames.Add(Translator.Instance.Translate("inventory_util-enchantments-galaxy_soul", tokens: new
+                {
+                    progress_in_percentage = percentageCompleted
+                }));
+                continue;
+            }
+
             enchantNames.Add(enchantment.GetDisplayName());
         }
 

--- a/stardew-access/Utils/InventoryUtils.cs
+++ b/stardew-access/Utils/InventoryUtils.cs
@@ -65,7 +65,15 @@ internal static class InventoryUtils
         {
             if (!inventory[i].containsPoint(mouseX, mouseY)) continue;
 
-            if ((i + 1) > actualInventory.Count || actualInventory[i] == null)
+            if ((i + 1) > actualInventory.Count)
+            {
+                // For locked slots
+                CheckAndSpeak(Translator.Instance.Translate("inventory_util-locked_slot"), i);
+                prevSlotIndex = i;
+                return i;
+            }
+
+            if (actualInventory[i] == null)
             {
                 // For empty slot
                 CheckAndSpeak(Translator.Instance.Translate("inventory_util-empty_slot"), i);
@@ -86,7 +94,6 @@ internal static class InventoryUtils
                 highlightedItemSuffix);
 
             CheckAndSpeak(itemDetails, i);
-            prevSlotIndex = i;
             return i;
         }
 

--- a/stardew-access/Utils/TerrainUtils.cs
+++ b/stardew-access/Utils/TerrainUtils.cs
@@ -1,5 +1,6 @@
 using stardew_access.Translation;
 using StardewValley;
+using StardewValley.ItemTypeDefinitions;
 using StardewValley.TerrainFeatures;
 using System.Text;
 
@@ -145,7 +146,16 @@ public static class TerrainUtils
 
     public static string GetFlooringInfoString(Flooring flooring)
     {
-        // TODO Needs to be checked
+        if (!MainClass.Config.DisableDescriptiveFlooring)
+        {
+            ParsedItemData floorData = ItemRegistry.GetDataOrErrorItem(flooring.GetData().ItemId);
+            if (floorData != null && !floorData.IsErrorItem)
+            {
+                return floorData.DisplayName;
+            }
+        }
+
+        // Will run if DisableDescriptiveFlooring is on or when it's off but the above code wasn't able to get the floor data
         bool isPathway = flooring.whichFloor.Value is Flooring.gravel or Flooring.cobblestone or Flooring.wood or Flooring.ghost;
         bool isSteppingStone = flooring.whichFloor.Value == Flooring.steppingStone;
         string description = isPathway ? "tile_name-pathway" : (isSteppingStone ? "tile_name-stepping_stone" : "tile_name-flooring");

--- a/stardew-access/Utils/TileInfo.cs
+++ b/stardew-access/Utils/TileInfo.cs
@@ -12,7 +12,6 @@ using StardewValley.Monsters;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
 using StardewValley.TokenizableStrings;
-using StardewValley.Util;
 
 namespace stardew_access.Utils;
 
@@ -784,9 +783,11 @@ public class TileInfo
             });
             toReturn.category = CATEGORY.Doors;
         }
-        else if (correctNameAndCategory.name != null && !obj.ItemId.Contains("GreenRainWeeds"))
+        else if (correctNameAndCategory.name != null)
         {
-            correctNameAndCategory.name = MainClass.Config.ReadTileDebug ? $"{correctNameAndCategory.name} (DisplayName: {obj.DisplayName})" : correctNameAndCategory.name;
+            correctNameAndCategory.name = MainClass.Config.ReadTileDebug
+                ? $"{correctNameAndCategory.name} (DisplayName: {obj.DisplayName})"
+                : correctNameAndCategory.name;
             toReturn = correctNameAndCategory;
         }
         /*else if (obj.name.Equals("stone", StringComparison.OrdinalIgnoreCase))
@@ -813,6 +814,8 @@ public class TileInfo
         {
             if (!string.IsNullOrEmpty(obj.QualifiedItemId))
                 toReturn.name = $"{toReturn.name} ({obj.QualifiedItemId})";
+
+            // TODO Internationalize this...
             Farmer farmerOwner = Game1.getFarmerMaybeOffline(obj.owner.Value);
             string ownerName;
             if (farmerOwner == null)

--- a/stardew-access/assets/TileData/QualifiedItemIds.json
+++ b/stardew-access/assets/TileData/QualifiedItemIds.json
@@ -23,7 +23,15 @@
       "(O)786",
       "(O)882",
       "(O)883",
-      "(O)884"
+      "(O)884",
+      "(O)GreenRainWeeds0",
+      "(O)GreenRainWeeds1",
+      "(O)GreenRainWeeds2",
+      "(O)GreenRainWeeds3",
+      "(O)GreenRainWeeds4",
+      "(O)GreenRainWeeds5",
+      "(O)GreenRainWeeds6",
+      "(O)GreenRainWeeds7",
     ],
     "tile-fertile_weed_name": [
       "(O)792",

--- a/stardew-access/i18n/en.ftl
+++ b/stardew-access/i18n/en.ftl
@@ -513,6 +513,8 @@ inventory_util-special_items-name = {$item_id ->
     *[other] -9999
   }
 
+inventory_util-enchantments-galaxy_soul = Galaxy Soul ({$progress_in_percentage}% transformed)
+
 common-unknown = Unknown
 
 # The $name will be in the respective language i.e., it will be in french for french translation and so on. So use the language specific name in the square brackets except for the one with '*', that can have any value. Variants with '*' are marked as default.

--- a/stardew-access/i18n/en.ftl
+++ b/stardew-access/i18n/en.ftl
@@ -490,6 +490,7 @@ direction-south_east = Southeast
 direction-current_tile = Current tile
 
 inventory_util-empty_slot = Empty Slot
+inventory_util-locked_slot = Locked Slot
 
 # Primarily used to distinguish items with same name, like Jungle Decals or Ceiling Leaves purchased in Luau
 inventory_util-special_items-name = {$item_id ->

--- a/stardew-access/i18n/menu.en.ftl
+++ b/stardew-access/i18n/menu.en.ftl
@@ -257,7 +257,10 @@ menu-animal_page-animal_info = {$name}, {$type}{$heart_count ->
 
 ### Forge Menu
 
-menu-forge-start_forging_button = Start forging button
+menu-forge-start_forging_button = Start forging button{$forge_cost ->
+    [0] {EMPTYSTRING()}
+    *[other] , costs {$forge_cost} Cinder Shards
+  }
 menu-forge-unforge_button = Unforge button
 menu-forge-weapon_input_slot = {$is_empty ->
     [0] Weapon slot: {$item_name}


### PR DESCRIPTION
## Changelog

### Feature Updates

- Inventory slots that haven't been unlocked yet now appropriately read as "Locked Slot" instead of "Empty Slot"; #361 

### Bug Fixes

- Fixed support for medowlands and custom farm types in the custom tile entry menu.
- Fixed descriptive flooring names not being read. Introduced a new config, `DisableDescriptiveFlooring`; #362 
- Fixed green rain weeds being categorized as other instead of debris; #365 

### Translation Changes

- New(en.ftl): `inventory_util-locked_slot` = `Locked Slot`
- New(en.ftl): `inventory_util-enchantments-galaxy_soul` = `Galaxy Soul ({$progress_in_percentage}% transformed)`
- Modified(menu.en.ftl): `menu-forge-start_forging_button` = [English value](https://github.com/khanshoaib3/stardew-access/blob/499637832b0801a75c4435517e0420c08a06bbeb/stardew-access/i18n/menu.en.ftl#L260-L263)

### Misc

- Added progress information for infinity conversion (galaxy soul enchantment); #239 
- "Start Forging" button in the forge menu now also speaks the forge cost.
- The special orders board menu now correctly indicates when a quest is completed; #228 
