### PR TITLE
[WIP] Auto Release Notes Generation in Release Workflow and More

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 [//]: # (3. Do not change the heading names and/or the heading levels)
 [//]: # (4. Remove the unwanted changelog sections)
 
+
 ## Changelog
 
 ### New Features
@@ -15,9 +16,6 @@
 ### Bug Fixes
 
 
-### Translation Changes
-
-
 ### Tile Tracker Changes
 
 
@@ -25,5 +23,11 @@
 
 
 ### Misc
+
+
+### Translation Changes
+
+
+### Development Chores
 
 

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -10,11 +10,9 @@ jobs:
     name: fast-forward
 
     # Ref: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-    # contents: For adding the commit
     # issues: For adding the success/failure comments
     # pull-requests: For some reason, even though I gave write perms to issues, it wasn't able to send the success/failure comment to PR, so maybe having pull-requests to write will?
     permissions:
-      contents: write
       issues: write
       pull-requests: write
 
@@ -109,18 +107,18 @@ jobs:
         if: env.MERGE_STATUS == 'clean' || contains(github.event.comment.body, '/fast-forward-force')
         run: |
           if [[ "$( tail ./response.txt -n 1 )" = 'No changes to write!' ]] || [[ "$( tail ./response.txt -n 1 )" =~ "File \`(.*?)\` not found\!" ]]; then
-            echo "COMMENT=${{ env.COMMENT }}\nNo changelogs found..." >> $GITHUB_ENV
+            echo "COMMENT=${{ env.COMMENT }}\<br\/\>No changelogs found..." >> $GITHUB_ENV
           else
             git add docs/changelogs/latest.md
-            git commit -m ":memo: Add changelogs from #${{ github.event.issue.number }} to latest.md"
-            echo "COMMENT=${{ env.COMMENT }}\nCopied the changelogs from pull request body to docs/changelogs/latest.md..." >> $GITHUB_ENV
+            git commit -m "docs: Add changelogs from #${{ github.event.issue.number }} to latest.md"
+            echo "COMMENT=${{ env.COMMENT }}\<br\/\>Copied the changelogs from pull request body to docs/changelogs/latest.md..." >> $GITHUB_ENV
           fi
 
       - name: Push to origin
         if: env.MERGE_STATUS == 'clean' || contains(github.event.comment.body, '/fast-forward-force')
         run: |
           git push origin
-          echo "COMMENT=${{ env.COMMENT }}\nPushed the changes to origin." >> $GITHUB_ENV
+          echo "COMMENT=${{ env.COMMENT }}\<br\/\>Pushed the changes to origin." >> $GITHUB_ENV
 
       # Post a success/failure comment to the PR.
       - name: Add success/failure comment to PR
@@ -131,7 +129,7 @@ jobs:
           issue_number: ${{ github.event.issue.number }}
           body: ${{ env.COMMENT }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Post a failure message when any of the previous steps fail.
       - name: Add failure comment to PR
@@ -143,4 +141,4 @@ jobs:
           issue_number: ${{ github.event.issue.number }}
           body: \[Fast Forward CI\] PR cannot be merged in. Check the Actions tab for details.
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 # ACT (for testing workflows locally): https://nektosact.com/
 # Example commands:
 # $ docker run -d --name artifact-server -p 8080:8080 --add-host host.docker.internal:host-gateway -e AUTH_KEY=foo ghcr.io/jefuller/artifact-server:latest
-# $ sudo act --env ACTIONS_RUNTIME_URL=http://host.docker.internal:8080/ --env ACTIONS_RUNTIME_TOKEN=foo --env ACTIONS_CACHE_URL=http://host.docker.internal:8080/ --artifact-server-path act_out -W ./.github/workflows/release.yml
+# $ sudo act --env ACTIONS_RUNTIME_URL=http://host.docker.internal:8080/ --env ACTIONS_RUNTIME_TOKEN=foo --env ACTIONS_CACHE_URL=http://host.docker.internal:8080/ --artifact-server-path act_out -W ./.github/workflows/release.yml --input github-upload=false --input nexus-upload=false --input detailed-release-notes=true
 
 # Can only be called manually from the actions tab on github repo.
 on:
@@ -27,6 +27,11 @@ on:
           - false
       set-latest:
         description: 'Set as latest on github and nexus'
+        required: false
+        default: false
+        type: boolean
+      detailed-release-notes:
+        description: 'Whether to generate detailed release notes or not'
         required: false
         default: false
         type: boolean
@@ -64,6 +69,8 @@ jobs:
     steps:
       - name: Pull source code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       # Ref: https://github.com/actions/download-artifact
       - name: Download artifacts from build workflow run
@@ -105,12 +112,31 @@ jobs:
       #     echo ${{ env.NEXUSMOD_VERSION }}
       #     echo ${{ env.NEXUSMOD_MODID }}
 
+      - name: Generate release notes and final changelog file
+        run: |
+          cd docs/changelogs/scripts
+          python gen_final_changelog_n_release_notes.py ${{ inputs.detailed-release-notes && '-d' || '' }} -v ${{ env.RELEASE_TAG }} -p ${{ env.PRE_RELEASE }}
+          mv ../temp_notes.md ../../../temp_notes.md
+          cd ../../../
+
+      # git --no-pager log --oneline -10
+      - name: Commit and push docs changes
+        run: |
+          git config --global user.email "<>"
+          git config --global user.name "GitHub Actions [Bot]"
+          git add docs/changelogs/
+          git status
+          git commit -m "docs: Generate final changelog file for ${{ env.RELEASE_TAG }}"
+          git push origin
+
+
       # Ref: https://github.com/softprops/action-gh-release
       - name: Upload on GitHub
         if: inputs.github-upload
         uses: softprops/action-gh-release@v2
         with:
-          body: This is temporary and will be changed soon...
+          body_path: temp_notes.md
+          body: Encountered error in generating automatic release note, this will updated soon...
           prerelease: ${{ env.PRE_RELEASE }}
           files: |
             ${{ env.MAIN_FILE }}

--- a/docs/changelogs/default.md
+++ b/docs/changelogs/default.md
@@ -9,9 +9,6 @@
 ### Bug Fixes
 
 
-### Translation Changes
-
-
 ### Tile Tracker Changes
 
 
@@ -19,5 +16,8 @@
 
 
 ### Misc
+
+
+### Translation Changes
 
 

--- a/docs/changelogs/default.md
+++ b/docs/changelogs/default.md
@@ -21,3 +21,6 @@
 ### Translation Changes
 
 
+### Development Chores
+
+

--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -24,20 +24,6 @@
 - Fixed descriptive flooring names not being read. Introduced a new config, `DisableDescriptiveFlooring`; #362
 - Fixed green rain weeds being categorized as other instead of debris; #365
 
-### Translation Changes
-
-- New(en.ftl): `event_tile-luau-pierre_booth` = `Pierre's Booth`
-- Modified(en.ftl): `npc-farm_animal_info` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/en.ftl#L333-L348)
-- New(en.ftl): `tile-town-bookseller` = `Bookseller`
-- Removed(static_tiles.en.ftl): `static_tile-town-bookseller`
-- Modified(menu.en.ftl): `menu-animal_query-animal_info` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/menu.en.ftl#L345-L367)
-- New(en.ftl): `dynamic_tile-farm-lumber_pile` = `Lumber Pile`.
-- Removed(static_tiles.en.ftl): `static_tile-farm-lumber_pile`.
-- New(en.ftl): `inventory_util-special_items-name` with placeholder values at the moment.
-- New(en.ftl): `inventory_util-locked_slot` = `Locked Slot`
-- New(en.ftl): `inventory_util-enchantments-galaxy_soul` = `Galaxy Soul ({$progress_in_percentage}% transformed)`
-- Modified(menu.en.ftl): `menu-forge-start_forging_button` = [English value](https://github.com/khanshoaib3/stardew-access/blob/499637832b0801a75c4435517e0420c08a06bbeb/stardew-access/i18n/menu.en.ftl#L260-L263)
-
 ### Tile Tracker Changes
 
 - Bookseller's tile is now dynamically tracked.
@@ -55,4 +41,18 @@
 - Added progress information for infinity conversion (galaxy soul enchantment); #239
 - "Start Forging" button in the forge menu now also speaks the forge cost.
 - The special orders board menu now correctly indicates when a quest is completed; #228
+
+### Translation Changes
+
+- New(en.ftl): `event_tile-luau-pierre_booth` = `Pierre's Booth`
+- Modified(en.ftl): `npc-farm_animal_info` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/en.ftl#L333-L348)
+- New(en.ftl): `tile-town-bookseller` = `Bookseller`
+- Removed(static_tiles.en.ftl): `static_tile-town-bookseller`
+- Modified(menu.en.ftl): `menu-animal_query-animal_info` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/a33d90157baa532e09f45d72bed91ff53a601649/stardew-access/i18n/menu.en.ftl#L345-L367)
+- New(en.ftl): `dynamic_tile-farm-lumber_pile` = `Lumber Pile`.
+- Removed(static_tiles.en.ftl): `static_tile-farm-lumber_pile`.
+- New(en.ftl): `inventory_util-special_items-name` with placeholder values at the moment.
+- New(en.ftl): `inventory_util-locked_slot` = `Locked Slot`
+- New(en.ftl): `inventory_util-enchantments-galaxy_soul` = `Galaxy Soul ({$progress_in_percentage}% transformed)`
+- Modified(menu.en.ftl): `menu-forge-start_forging_button` = [English value](https://github.com/khanshoaib3/stardew-access/blob/499637832b0801a75c4435517e0420c08a06bbeb/stardew-access/i18n/menu.en.ftl#L260-L263)
 

--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -35,9 +35,6 @@
 
 ### Misc
 
-- Added pull request template
-- ci: As opposed to `/fast-forward`, we can also now use `/fast-forward-force` to merge the PR without checking for `mergeable_state`.
-- ci: Fix if condition failure in fast-forward.yml
 - Added progress information for infinity conversion (galaxy soul enchantment); #239
 - "Start Forging" button in the forge menu now also speaks the forge cost.
 - The special orders board menu now correctly indicates when a quest is completed; #228
@@ -55,4 +52,10 @@
 - New(en.ftl): `inventory_util-locked_slot` = `Locked Slot`
 - New(en.ftl): `inventory_util-enchantments-galaxy_soul` = `Galaxy Soul ({$progress_in_percentage}% transformed)`
 - Modified(menu.en.ftl): `menu-forge-start_forging_button` = [English value](https://github.com/khanshoaib3/stardew-access/blob/499637832b0801a75c4435517e0420c08a06bbeb/stardew-access/i18n/menu.en.ftl#L260-L263)
+
+### Development Chores
+
+- Added pull request template
+- ci: As opposed to `/fast-forward`, we can also now use `/fast-forward-force` to merge the PR without checking for `mergeable_state`.
+- ci: Fix if condition failure in fast-forward.yml
 

--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -2,6 +2,15 @@
 
 ### New Features
 
+- Configure automatic reading of dialogs; new manual read dialog key (by @ParadoxiKat)
+    - New config option `AutoReadCharacterBubbles` (default: true) can be disabled to prevent character speech bubbles from reading.
+    - New config option `AutoReadCharacterDialog` (default: true) can be disabled to prevent character dialogs from reading when first opened.
+    - New config option `AutoReadQuestionDialog` (default: true) can be disabled to prevent question dialogs (such as go to bed? TV etc) from reading when first opened.
+    - New config option `AutoReadBasicDialog` (default: true) can be disabled to prevent basic dialogs (such as unable to use basic axe on large stump) from reading when first opened.
+    - New config option `ManualReadDialogKey` (default: "R") can be pressed in any dialog to reread it as if just opened, regardless of related verbosity setting.
+- Patched home renovations menu
+    - Use the `PrimaryInfoKey` in the menu to snap the mouse to the renovation area and speak the details about the affected area.
+      Then use `LeftClick` to renovate.
 
 ### Feature Updates
 

--- a/docs/changelogs/scripts/copy_changelogs_to.py
+++ b/docs/changelogs/scripts/copy_changelogs_to.py
@@ -10,7 +10,10 @@ headings = ['### New Features', '### Feature Updates', '### Bug Fixes', '### Tra
 
 def main():
     source_path, dest_path = get_file_names_from_cli()
+    copy_changelog(source_path, dest_path)
 
+
+def copy_changelog(source_path: str, dest_path: str):
     src_file = open(source_path, "r").readlines()
     dest_file = open(dest_path, "r").readlines()
 
@@ -59,6 +62,20 @@ def main():
         print("\n\nOverwriting destination file with the content:")
         print(*dest_file)
         dest_file_w.writelines(dest_file)
+
+
+def get_changelogs_dict(file_path: str) -> dict:
+    file = open(file_path, "r").readlines()
+    file = [line.rstrip() for line in file]  # Remove trailing spaces
+    h_changelogs = dict()
+
+    for heading in headings:
+        if (heading not in file):
+            continue
+
+        h_changelogs[heading] = get_changelogs_for_heading_in_file(heading, file)
+
+    return h_changelogs
 
 
 def get_changelogs_for_heading_in_file(heading: str, file_contents: list) -> list:

--- a/docs/changelogs/scripts/copy_changelogs_to.py
+++ b/docs/changelogs/scripts/copy_changelogs_to.py
@@ -6,7 +6,7 @@ import os
 
 headings = ['### New Features', '### Feature Updates', '### Bug Fixes',
             '### Tile Tracker Changes', '### Guides And Docs', '### Misc',
-            '### Translation Changes']
+            '### Translation Changes', '### Development Chores']
 
 
 def main():

--- a/docs/changelogs/scripts/copy_changelogs_to.py
+++ b/docs/changelogs/scripts/copy_changelogs_to.py
@@ -4,8 +4,9 @@ import argparse
 import os
 
 
-headings = ['### New Features', '### Feature Updates', '### Bug Fixes', '### Translation Changes',
-            '### Tile Tracker Changes', '### Guides And Docs', '### Misc']
+headings = ['### New Features', '### Feature Updates', '### Bug Fixes',
+            '### Tile Tracker Changes', '### Guides And Docs', '### Misc',
+            '### Translation Changes']
 
 
 def main():

--- a/docs/changelogs/scripts/gen_final_changelog_n_release_notes.py
+++ b/docs/changelogs/scripts/gen_final_changelog_n_release_notes.py
@@ -1,0 +1,106 @@
+import argparse
+import re
+import os
+import shutil
+import json
+import copy_changelogs_to
+
+
+def main():
+    version, release_notes_path, detailed_release_notes = get_version_n_output_file_name_from_cli()
+
+    if version == 'auto':
+        version = get_version_from_manifest()
+
+    final_changelog_path = f'../{version}.md'
+
+    print(f'Version: {version}')
+    print(f'Final changelog file path: {final_changelog_path}')
+    print(f'Release notes path: {final_changelog_path}\n')
+    print('Generating final changelog...')
+
+    gen_final_changelog_file(final_changelog_path,
+                             ('beta' in version or 'alpha' in version))
+    print('Generating release notes...')
+    gen_release_notes(release_notes_path, final_changelog_path,
+                      detailed_release_notes, version)
+
+
+def gen_release_notes(release_notes_path: str,
+                      from_path: str,
+                      detailed: bool,
+                      version: str):
+    print(f'Detailed release notes generation: {detailed}')
+    release_notes_file = open(release_notes_path, 'w')
+    release_notes = []
+    changelogs_dict = copy_changelogs_to.get_changelogs_dict(from_path)
+    for heading, changelogs in changelogs_dict.items():
+        if not detailed and heading != '### New Features' and heading != '### Feature Updates':
+            continue
+        if heading == '### Translation Changes':
+            continue
+        if len(changelogs) == 0:
+            continue
+
+        print(f'Copying changelogs with heading: {heading}')
+        release_notes += [heading, ''] + changelogs + ['']
+
+    print(f'Adding in links to full changelogs and translation changes...')
+    changelog_link = f'https://github.com/khanshoaib3/stardew-access/blob/development/docs/changelogs/{version}.md'
+    release_notes = ['## Changelog', ''] + release_notes
+    release_notes += ['', f'Translators please refer to this link for a list of translation changes: {changelog_link}#translation-changes']
+    release_notes += [f'Full changelog at: {changelog_link}']
+    release_notes = [f'{line}\n' for line in release_notes]  # Add trailing line break
+    release_notes_file.writelines(release_notes)
+    release_notes_file.close()
+
+
+def gen_final_changelog_file(final_changelog_path: str, is_pre_release: bool):
+    latest_file = '../latest.md'
+    default_file = '../default.md'
+    open(final_changelog_path, 'w').close()  # Creates an empty file
+
+    if is_pre_release:
+        print(f'Copying contents of latest.md directly as the version is pre release...')
+        shutil.copyfile(latest_file, final_changelog_path)
+        shutil.copyfile(default_file, latest_file)
+        return
+
+    # Merge changelogs from betas and alphas into the final changelog
+    patt: str = r"v[0-9]+\.[0-9]+\.[0-9]+.*\.md"
+    versions_paths = [f'../{f}' for f in os.listdir('../')
+                      if re.match(patt, f) and ('beta' in f or 'alpha' in f)]
+    shutil.copyfile(default_file, final_changelog_path)
+    print(f'Merging contents of latest.md with following file:', *versions_paths)
+
+    for versions_path in versions_paths:
+        print(f'Copying contents of and then removing {versions_path}...')
+        copy_changelogs_to.copy_changelog(versions_path, final_changelog_path)
+        os.remove(versions_path)
+
+    print(f'Copying contents of latest.md...')
+    copy_changelogs_to.copy_changelog(latest_file, final_changelog_path)
+
+    print('Resetting latest.md...')
+    shutil.copyfile(default_file, latest_file)
+
+
+def get_version_from_manifest() -> str:
+    manifest_json_file = open('../../../stardew-access/manifest.json')
+    manifest_json = json.load(manifest_json_file)
+    manifest_json_file.close()
+    return f"v{manifest_json['Version']}"
+
+
+def get_version_n_output_file_name_from_cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--version', default='auto')
+    parser.add_argument('-o', '--output', default='../temp_notes.md')
+    parser.add_argument('-d', '--detailed', action='store_true')
+
+    parsed_args = parser.parse_args()
+    return [parsed_args.version, parsed_args.output, parsed_args.detailed]
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/changelogs/scripts/gen_final_changelog_n_release_notes.py
+++ b/docs/changelogs/scripts/gen_final_changelog_n_release_notes.py
@@ -69,6 +69,8 @@ def gen_release_notes(release_notes_path: str,
             continue
         if heading == '### Translation Changes':
             continue
+        if heading == '### Development Chores':
+            continue
         if len(changelogs) == 0:
             continue
 

--- a/docs/changelogs/scripts/gen_final_changelog_n_release_notes.py
+++ b/docs/changelogs/scripts/gen_final_changelog_n_release_notes.py
@@ -7,7 +7,7 @@ import copy_changelogs_to
 
 
 def main():
-    version, release_notes_path, detailed_release_notes = get_version_n_output_file_name_from_cli()
+    version, release_notes_path, detailed_release_notes, pre_release = get_version_n_output_file_name_from_cli()
 
     if version == 'auto':
         version = get_version_from_manifest()
@@ -16,11 +16,16 @@ def main():
 
     print(f'Version: {version}')
     print(f'Final changelog file path: {final_changelog_path}')
-    print(f'Release notes path: {final_changelog_path}\n')
-    print('Generating final changelog...')
+    print(f'Release notes path: {final_changelog_path}')
 
-    gen_final_changelog_file(final_changelog_path,
-                             ('beta' in version or 'alpha' in version))
+    if pre_release == 'auto':
+        is_pre_release = ('beta' in version or 'alpha' in version)
+    else:
+        is_pre_release = True if pre_release == 'true' else False
+    print(f'Is pre release: {is_pre_release}\n')
+
+    print('Generating final changelog...')
+    gen_final_changelog_file(final_changelog_path, is_pre_release)
     print('Generating release notes...')
     gen_release_notes(release_notes_path, final_changelog_path,
                       detailed_release_notes, version)
@@ -97,9 +102,10 @@ def get_version_n_output_file_name_from_cli():
     parser.add_argument('-v', '--version', default='auto')
     parser.add_argument('-o', '--output', default='../temp_notes.md')
     parser.add_argument('-d', '--detailed', action='store_true')
+    parser.add_argument('-p', '--pre-release', dest='pre_release', default='auto')
 
     parsed_args = parser.parse_args()
-    return [parsed_args.version, parsed_args.output, parsed_args.detailed]
+    return [parsed_args.version, parsed_args.output, parsed_args.detailed, parsed_args.pre_release]
 
 
 if __name__ == "__main__":

--- a/docs/changelogs/v1.6.0-beta.1.md
+++ b/docs/changelogs/v1.6.0-beta.1.md
@@ -40,6 +40,12 @@
 - Added unread mail count to mailbox when there is mail and moved it to Pending category - @ParadoxiKat.
 - Prepend other players names to mailboxes and cabins/farmhouse. The owner name is pre-pended to the cabin/farm house only if it is not of the current owner. So, for the second player, the cabin's mail box will be read as Mail Box while the farm house's mail box will be read as [First player's name] Mail Box without the unread mail count status. - @khanshoaib3
 
+### Misc
+
+- Optimize category look ups for builtin categories - @ParadoxiKat.
+- Reimplement social page patch; it now speaks whether or not you have met the npc - @ParadoxiKat.
+- Added buffs info (if applicable) and ingredients and proper description of purchasable recipes from shop menus - @khanshoaib3.
+
 ### Translation Changes
 
 - Modified(character_creation.en.ftl): `menu-character_creation-description-shirt` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/b399274aec21fc520c2fe0a076e49f1c17c4bafa/stardew-access/i18n/character_creation_menu.en.ftl#L229-L346)
@@ -64,10 +70,4 @@
 - New(menu.en.ftl): `menu-letter_viewer-image_note` = [English value](https://github.com/khanshoaib3/stardew-access/blob/b399274aec21fc520c2fe0a076e49f1c17c4bafa/stardew-access/i18n/menu.en.ftl#L398-L407)
 - Modified(menu.en.ftl): `menu-billboard-calendar-day_info` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/b399274aec21fc520c2fe0a076e49f1c17c4bafa/stardew-access/i18n/menu.en.ftl#L460-L469)
 - New(static_tiles.en.ftl): `static_tile-movie_theater-town_entrance` = `Town`
-
-### Misc
-
-- Optimize category look ups for builtin categories - @ParadoxiKat.
-- Reimplement social page patch; it now speaks whether or not you have met the npc - @ParadoxiKat.
-- Added buffs info (if applicable) and ingredients and proper description of purchasable recipes from shop menus - @khanshoaib3.
 

--- a/docs/changelogs/v1.6.0-beta.2.md
+++ b/docs/changelogs/v1.6.0-beta.2.md
@@ -33,6 +33,14 @@
 - Dropped wood from trees now properly tracked - @khanshoaib3
 - Track tents. Most of the tent is tracked under buildings, entrance tracked under interactables - @ParadoxiKat
 
+### Misc
+
+- Append content of text signs (if any) - @khanshoaib3
+- Speak farm building's name instead of farm name when entering - @khanshoaib3
+- Improve handling for unknown terrain features; new category unknown - @ParadoxiKat
+- Add config option to disable fluent pluralization - @ParadoxiKat
+- Show correct game number in load game menu - @khanshoaib3
+
 ### Translation Changes
 
 - Pluralize "Hay" properly as "handfuls of hay" - @ParadoxiKat 
@@ -77,12 +85,4 @@
 - New(static_tiles.en.ftl): `static_tile-mine-mountain_entrance_west` = `Mountain Entrance (West)`
 - New(static_tiles.en.ftl): `static_tile-mountain-quarry_mine_entrance` = `Quarry Mine Entrance`
 - Removed(static_tiles.en.ftl): `static_tile-volcanodungeon5-dwarf_shop`
-
-### Misc
-
-- Append content of text signs (if any) - @khanshoaib3 
-- Speak farm building's name instead of farm name when entering - @khanshoaib3 
-- Improve handling for unknown terrain features; new category unknown - @ParadoxiKat 
-- Add config option to disable fluent pluralization - @ParadoxiKat 
-- Show correct game number in load game menu - @khanshoaib3 
 

--- a/docs/changelogs/v1.6.0-beta.3.md
+++ b/docs/changelogs/v1.6.0-beta.3.md
@@ -41,6 +41,15 @@
 - Track boulder blocking cave in Island North - @ParadoxiKat
 - Track Mushroom Log - @ParadoxiKat
 
+### Misc
+
+- Use DisplayName of NPC for proper translation in SocialPagePatch - @khanshoaib3
+- Rename config option ReadTileIndexes to ReadTileDebug - @ParadoxiKat
+- Add stardew-access version to the "Initializing stardew-access" string - @ParadoxiKat
+- Remove `=` from new twigs and rocks descriptions - @ParadoxiKat
+- Lower relative volume of "You've got mail" notification sound - @ParadoxiKat
+- Enable "You've got mail!" and unread mail count on island farm - @ParadoxiKat
+
 ### Translation Changes
 
 - New(en.ftl): `feature-speak_youve_got_mail` = `You've got mail!`
@@ -87,13 +96,4 @@
 - New(static_tiles.en.ftl): `static_tile-town-joja_billboard` = `Joja Billboard with text "Joja Cola: Fuel Your Life"`
 - New(static_tiles.en.ftl): `static_tile-town-museum_bridge` = `Museum Bridge`
 - New(static_tiles.en.ftl): `static_tile-town-bookseller` = `Bookseller`
-
-### Misc
-
-- Use DisplayName of NPC for proper translation in SocialPagePatch - @khanshoaib3
-- Rename config option ReadTileIndexes to ReadTileDebug - @ParadoxiKat
-- Add stardew-access version to the "Initializing stardew-access" string - @ParadoxiKat
-- Remove `=` from new twigs and rocks descriptions - @ParadoxiKat
-- Lower relative volume of "You've got mail" notification sound - @ParadoxiKat
-- Enable "You've got mail!" and unread mail count on island farm - @ParadoxiKat
 

--- a/docs/changelogs/v1.6.0-beta.4.md
+++ b/docs/changelogs/v1.6.0-beta.4.md
@@ -43,6 +43,10 @@
 - More info is added to the setup page to make the instructions easier to follow. The readme page has been improved to better convey what the mod is about at a glance - @PepperTheVixen.
 - Provided instructions for how to use the new [Accessible Stardew Setup](https://github.com/ParadoxiKat/AccessibleStardewSetup/) - @PepperTheVixen.
 
+### Misc
+
+- Updated skills page patch to reflect new additions.
+
 ### Translation Changes
 
 - Modified(menu.en.ftl): `menu-skills_page-player_info` = [Updated English value](https://github.com/khanshoaib3/stardew-access/blob/204d3b41aef01c5a57146b8b6a7b04acf090cc75/stardew-access/i18n/menu.en.ftl#L214-L238)
@@ -53,8 +57,4 @@
 - New(static_tiles.en.ftl): `static_tile-fishshop-bobber_machine` = `Bobber Machine`
 - New(static_tiles.en.ftl): `static_tile-fishshop-miniature_frigate` = `Miniature Frigate`
 - New(static_tiles.en.ftl): `static_tile-fishshop-tackle_box` = `Tackle Box`
-
-### Misc
-
-- Updated skills page patch to reflect new additions.
 

--- a/stardew-access/manifest.json
+++ b/stardew-access/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Stardew Access",
   "Author": "Mohammad Shoaib Khan and Katalina Tudela",
-  "Version": "1.6.0-beta.4",
+  "Version": "1.6.0-beta.5",
   "Description": "A mod that improves the accessibility of the game for visually impaired players.",
   "UniqueID": "shoaib.stardewaccess",
   "EntryDll": "stardew-access.dll",


### PR DESCRIPTION
## Changelog

### Development Chores

- Updated the `release` workflow to automatically generate release notes. Added a helper python script for it, `gen_final_changelog_n_release_notes.py`.
- New sub-heading for changelogs, `Development Chores`.
- Updated the order of `Translation Changes` sub-heading to be at last with `Development Chores`.
