### PR TITLE
Tile properties

### DIFF
--- a/stardew-access/API.cs
+++ b/stardew-access/API.cs
@@ -3,6 +3,7 @@ using stardew_access.Features;
 using stardew_access.Patches;
 using stardew_access.Translation;
 using stardew_access.Utils;
+using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 // ReSharper disable UnusedMember.Global
@@ -49,6 +50,8 @@ namespace stardew_access
             get => MainClass.ScreenReader.MenuSuffixNoQueryText;
             set => MainClass.ScreenReader.MenuSuffixNoQueryText = value;
         }
+
+        public KeybindList PrimaryInfoKey => MainClass.Config.PrimaryInfoKey;
 
         public bool Say(String text, Boolean interrupt)
             => MainClass.ScreenReader.Say(text, interrupt);

--- a/stardew-access/Patches/MiscPatches/IClickableMenuPatch.cs
+++ b/stardew-access/Patches/MiscPatches/IClickableMenuPatch.cs
@@ -96,13 +96,16 @@ internal class IClickableMenuPatch : IPatch
         typeof(TileDataEntryMenu),
     ];
 
-    private static bool _justOpened = true;
     private static bool _tryHoverPatch = false;
 
     internal static HashSet<string> ManuallyPatchedCustomMenus = [];
 
     internal static string? CurrentMenu;
     internal static bool ManuallyCallingDrawPatch = false;
+
+#if DEBUG
+    private static bool _justOpened = true;
+#endif
 
     public void Apply(Harmony harmony)
     {
@@ -160,8 +163,6 @@ internal class IClickableMenuPatch : IPatch
 
             /* v1.6.9
             if (activeMenu.currentlySnappedComponent == null || string.IsNullOrWhiteSpace(activeMenu!.currentlySnappedComponent.ScreenReaderText))
-            */
-            if (activeMenu.currentlySnappedComponent == null)
             {
                 if (OptionsElementUtils.NarrateOptionSlotsInMenuUsingReflection(activeMenu))
                     return;
@@ -177,12 +178,30 @@ internal class IClickableMenuPatch : IPatch
                 return;
             }
 
+            if (ClickableComponentUtils.NarrateHoveredComponentFromList(activeMenu.allClickableComponents))
+            {
+                return;
+            }
+            */
+
+            if (OptionsElementUtils.NarrateOptionSlotsInMenuUsingReflection(activeMenu))
+                return;
+
+            if (ClickableComponentUtils.NarrateHoveredComponentUsingReflectionInMenu(activeMenu))
+            {
+                return;
+            }
 
             if (ClickableComponentUtils.NarrateHoveredComponentFromList(activeMenu.allClickableComponents))
             {
                 return;
             }
 
+            if (activeMenu.currentlySnappedComponent != null)
+            {
+                ClickableComponentUtils.NarrateComponent(activeMenu.currentlySnappedComponent);
+                return;
+            }
 
             _tryHoverPatch = true;
         }
@@ -332,7 +351,10 @@ internal class IClickableMenuPatch : IPatch
         TextBoxPatch.activeTextBoxes = "";
         CurrentMenu = null;
         ManuallyCallingDrawPatch = false;
-        _justOpened = true;
         _tryHoverPatch = false;
+
+#if DEBUG
+        _justOpened = true;
+#endif
     }
 }

--- a/stardew-access/PublicApi/IStardewAccessApi.cs
+++ b/stardew-access/PublicApi/IStardewAccessApi.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using stardew_access.Translation;
+using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -43,6 +44,12 @@ public interface IStardewAccessApi
     /// <br />Resets everytime after use.
     /// </summary>
     public string MenuSuffixNoQueryText { get; set; }
+
+    /// <summary>
+    /// (Default to `C`) Mainly used to speak some visual information in a menu like some label(s) which isn't
+    /// reachable by gamepad naviagtion.
+    /// </summary>
+    public KeybindList PrimaryInfoKey { get; }
 
     /// <summary>Speaks the text via the loaded screen reader (if any).</summary>
     /// <param name="text">The text to be narrated.</param>

--- a/stardew-access/Utils/Category.cs
+++ b/stardew-access/Utils/Category.cs
@@ -1,159 +1,158 @@
 using stardew_access.Translation;
 
-namespace stardew_access.Utils
+namespace stardew_access.Utils;
+
+/// <summary>
+/// Represents categories that objects can belong to. This class provides predefined categories
+/// accessible as static properties and supports adding new categories at runtime. Predefined categories
+/// can be accessed like enum values, while both static and dynamic categories can be accessed via the
+/// `Categories` property or the `FromString` method.
+/// </summary>
+/// <remarks>
+/// The CATEGORY.Other is used as a default value by the FromString method.
+/// Use the FromString method to obtain an existing category.
+///
+/// Examples:
+/// - Access a predefined category like an enum: CATEGORY.Farmers
+/// - Obtain a category using the FromString method: CATEGORY.FromString("farmer")
+/// - Add a new category: CATEGORY.AddNewCategory("custom_category")
+/// - Retrieve a category using the public dictionary: CATEGORY.Categories["custom_category"]
+/// - Obtain the string representation of a category: CATEGORY.Farmers.ToString()
+/// </remarks>
+public sealed class CATEGORY
 {
-    /// <summary>
-    /// Represents categories that objects can belong to. This class provides predefined categories
-    /// accessible as static properties and supports adding new categories at runtime. Predefined categories
-    /// can be accessed like enum values, while both static and dynamic categories can be accessed via the
-    /// `Categories` property or the `FromString` method.
-    /// </summary>
-    /// <remarks>
-    /// The CATEGORY.Other is used as a default value by the FromString method.
-    /// Use the FromString method to obtain an existing category.
-    ///
-    /// Examples:
-    /// - Access a predefined category like an enum: CATEGORY.Farmers
-    /// - Obtain a category using the FromString method: CATEGORY.FromString("farmer")
-    /// - Add a new category: CATEGORY.AddNewCategory("custom_category")
-    /// - Retrieve a category using the public dictionary: CATEGORY.Categories["custom_category"]
-    /// - Obtain the string representation of a category: CATEGORY.Farmers.ToString()
-    /// </remarks>
-    public sealed class CATEGORY
+    private readonly string _typeKeyWord;
+
+    private CATEGORY(string typeKeyWord)
     {
-        private readonly string _typeKeyWord;
-
-        private CATEGORY(string typeKeyWord)
-        {
-            _typeKeyWord = typeKeyWord;
-        }
-
-        public override string ToString()
-        {
-            if (!Translator.Instance.IsAvailable($"object_category-{_typeKeyWord}"))
-                return _typeKeyWord;
-
-            return Translator.Instance.Translate($"object_category-{_typeKeyWord}");
-        }
-
-        public string Key => _typeKeyWord;
-        public string Value => ToString();
-
-        public static IReadOnlyDictionary<string, CATEGORY> Categories => _categories;
-
-        private static readonly Dictionary<string, CATEGORY> _categories = new(StringComparer.OrdinalIgnoreCase)
-        {
-            {"animals", new CATEGORY("animals")},
-            {"bridges", new CATEGORY("bridges")},
-            {"buildings", new CATEGORY("buildings")},
-            {"bushes", new CATEGORY("bushes")},
-            {"bundles", new CATEGORY("bundles")},
-            {"containers", new CATEGORY("containers")},
-            {"crops", new CATEGORY("crops")},
-            {"debris", new CATEGORY("debris")},
-            {"decor", new CATEGORY("decor")},
-            {"doors", new CATEGORY("doors")},
-            {"dropped_items", new CATEGORY("dropped_items")},
-            {"farmers", new CATEGORY("farmers")},
-            {"fishing", new CATEGORY("fishing")},
-            {"fishponds", new CATEGORY("fish ponds")},
-            {"flooring", new CATEGORY("flooring")},
-            {"furniture", new CATEGORY("furniture")},
-            {"interactables", new CATEGORY("interactables")},
-            {"machines", new CATEGORY("machines")},
-            {"mine_items", new CATEGORY("mine_items")},
-            {"monsters", new CATEGORY("monsters")},
-            {"npcs", new CATEGORY("npcs")},
-            {"other", new CATEGORY("other")},
-            {"pending", new CATEGORY("pending")},
-            {"quest", new CATEGORY("quest")},
-            {"ready", new CATEGORY("ready")},
-            {"resource_clumps", new CATEGORY("resource_clumps")},
-            {"trees", new CATEGORY("trees")},
-            {"unknown", new CATEGORY("unknown")},
-            {"water", new CATEGORY("water")}
-        };
-
-
-        /// <summary>
-        /// Retrieves a CATEGORY instance by its string name.
-        /// Names are case-insensitive. If the name is not found, returns the 'Others' category.
-        /// </summary>
-        /// <param name="name">The string name of the category to retrieve.</param>
-        /// <returns>The CATEGORY instance corresponding to the given name or the 'Others' category if not found.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the provided name is null.</exception>
-        public static CATEGORY FromString(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("Category name cannot be null or empty.", nameof(name));
-            }
-
-            if (Categories.TryGetValue(name, out CATEGORY? category) && category != null)
-            {
-                return category;
-            } else {
-                if (AddNewCategory(name))
-                {
-                    if (Categories.TryGetValue(name, out var newCategory) && category != null)
-                        return newCategory;
-                }
-            }
-            return Other;
-        }
-
-        /// <summary>
-        /// Adds a new CATEGORY with the specified name.
-        /// Names are case-insensitive.
-        /// </summary>
-        /// <param name="name">The name of the new category to be added.</param>
-        /// <returns>
-        /// True if a new category was added; false if the category already exists.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">Thrown if the provided name is null or empty.</exception>
-        public static bool AddNewCategory(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("Name cannot be null or empty.", nameof(name));
-            }
-
-            if (!Categories.ContainsKey(name))
-            {
-                _categories[name] = new CATEGORY(name);
-                return true;
-            }
-            return false;
-        }
-
-        public static readonly CATEGORY Animals = FromString("animals");
-        public static readonly CATEGORY Bridges = FromString("bridges");
-        public static readonly CATEGORY Buildings = FromString("buildings");
-        public static readonly CATEGORY Bundles = FromString("bundles");
-        public static readonly CATEGORY Bushes = FromString("bushes");
-        public static readonly CATEGORY Containers = FromString("containers");
-        public static readonly CATEGORY Crops = FromString("crops");
-        public static readonly CATEGORY Debris = FromString("debris");
-        public static readonly CATEGORY Decor = FromString("decor");
-        public static readonly CATEGORY Doors = FromString("doors");
-        public static readonly CATEGORY DroppedItems = FromString("dropped_items");
-        public static readonly CATEGORY Farmers = FromString("farmers");
-        public static readonly CATEGORY Fishing = FromString("fishing");
-        public static readonly CATEGORY Fishponds = FromString("fishponds");
-        public static readonly CATEGORY Flooring = FromString("flooring");
-        public static readonly CATEGORY Furniture = FromString("furniture");
-        public static readonly CATEGORY Interactables = FromString("interactables");
-        public static readonly CATEGORY Machines = FromString("machines");
-        public static readonly CATEGORY MineItems = FromString("mine_items");
-        public static readonly CATEGORY Monsters = FromString("monsters");
-        public static readonly CATEGORY NPCs = FromString("npcs");
-        public static readonly CATEGORY Other = FromString("other");
-        public static readonly CATEGORY Pending = FromString("pending");
-        public static readonly CATEGORY Quest = FromString("quest");
-        public static readonly CATEGORY Ready = FromString("ready");
-        public static readonly CATEGORY ResourceClumps = FromString("resource_clumps");
-        public static readonly CATEGORY Trees = FromString("trees");
-        public static readonly CATEGORY Unknown = FromString("unknown");
-        public static readonly CATEGORY Water = FromString("water");
+        _typeKeyWord = typeKeyWord;
     }
+
+    public override string ToString()
+    {
+        if (!Translator.Instance.IsAvailable($"object_category-{_typeKeyWord}"))
+            return _typeKeyWord;
+
+        return Translator.Instance.Translate($"object_category-{_typeKeyWord}");
+    }
+
+    public string Key => _typeKeyWord;
+    public string Value => ToString();
+
+    public static IReadOnlyDictionary<string, CATEGORY> Categories => _categories;
+
+    private static readonly Dictionary<string, CATEGORY> _categories = new(StringComparer.OrdinalIgnoreCase)
+    {
+        {"animals", new CATEGORY("animals")},
+        {"bridges", new CATEGORY("bridges")},
+        {"buildings", new CATEGORY("buildings")},
+        {"bushes", new CATEGORY("bushes")},
+        {"bundles", new CATEGORY("bundles")},
+        {"containers", new CATEGORY("containers")},
+        {"crops", new CATEGORY("crops")},
+        {"debris", new CATEGORY("debris")},
+        {"decor", new CATEGORY("decor")},
+        {"doors", new CATEGORY("doors")},
+        {"dropped_items", new CATEGORY("dropped_items")},
+        {"farmers", new CATEGORY("farmers")},
+        {"fishing", new CATEGORY("fishing")},
+        {"fishponds", new CATEGORY("fish ponds")},
+        {"flooring", new CATEGORY("flooring")},
+        {"furniture", new CATEGORY("furniture")},
+        {"interactables", new CATEGORY("interactables")},
+        {"machines", new CATEGORY("machines")},
+        {"mine_items", new CATEGORY("mine_items")},
+        {"monsters", new CATEGORY("monsters")},
+        {"npcs", new CATEGORY("npcs")},
+        {"other", new CATEGORY("other")},
+        {"pending", new CATEGORY("pending")},
+        {"quest", new CATEGORY("quest")},
+        {"ready", new CATEGORY("ready")},
+        {"resource_clumps", new CATEGORY("resource_clumps")},
+        {"trees", new CATEGORY("trees")},
+        {"unknown", new CATEGORY("unknown")},
+        {"water", new CATEGORY("water")}
+    };
+
+
+    /// <summary>
+    /// Retrieves a CATEGORY instance by its string name.
+    /// Names are case-insensitive. If the name is not found, returns the 'Others' category.
+    /// </summary>
+    /// <param name="name">The string name of the category to retrieve.</param>
+    /// <returns>The CATEGORY instance corresponding to the given name or the 'Others' category if not found.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the provided name is null.</exception>
+    public static CATEGORY FromString(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentException("Category name cannot be null or empty.", nameof(name));
+        }
+
+        if (Categories.TryGetValue(name, out CATEGORY? category) && category != null)
+        {
+            return category;
+        }
+
+        if (AddNewCategory(name) && Categories.TryGetValue(name, out var newCategory) && newCategory != null)
+        {
+            return newCategory;
+        }
+
+        return Other;
+    }
+
+    /// <summary>
+    /// Adds a new CATEGORY with the specified name.
+    /// Names are case-insensitive.
+    /// </summary>
+    /// <param name="name">The name of the new category to be added.</param>
+    /// <returns>
+    /// True if a new category was added; false if the category already exists.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if the provided name is null or empty.</exception>
+    public static bool AddNewCategory(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentException("Name cannot be null or empty.", nameof(name));
+        }
+
+        if (!Categories.ContainsKey(name))
+        {
+            _categories[name] = new CATEGORY(name);
+            return true;
+        }
+        return false;
+    }
+
+    public static readonly CATEGORY Animals = FromString("animals");
+    public static readonly CATEGORY Bridges = FromString("bridges");
+    public static readonly CATEGORY Buildings = FromString("buildings");
+    public static readonly CATEGORY Bundles = FromString("bundles");
+    public static readonly CATEGORY Bushes = FromString("bushes");
+    public static readonly CATEGORY Containers = FromString("containers");
+    public static readonly CATEGORY Crops = FromString("crops");
+    public static readonly CATEGORY Debris = FromString("debris");
+    public static readonly CATEGORY Decor = FromString("decor");
+    public static readonly CATEGORY Doors = FromString("doors");
+    public static readonly CATEGORY DroppedItems = FromString("dropped_items");
+    public static readonly CATEGORY Farmers = FromString("farmers");
+    public static readonly CATEGORY Fishing = FromString("fishing");
+    public static readonly CATEGORY Fishponds = FromString("fishponds");
+    public static readonly CATEGORY Flooring = FromString("flooring");
+    public static readonly CATEGORY Furniture = FromString("furniture");
+    public static readonly CATEGORY Interactables = FromString("interactables");
+    public static readonly CATEGORY Machines = FromString("machines");
+    public static readonly CATEGORY MineItems = FromString("mine_items");
+    public static readonly CATEGORY Monsters = FromString("monsters");
+    public static readonly CATEGORY NPCs = FromString("npcs");
+    public static readonly CATEGORY Other = FromString("other");
+    public static readonly CATEGORY Pending = FromString("pending");
+    public static readonly CATEGORY Quest = FromString("quest");
+    public static readonly CATEGORY Ready = FromString("ready");
+    public static readonly CATEGORY ResourceClumps = FromString("resource_clumps");
+    public static readonly CATEGORY Trees = FromString("trees");
+    public static readonly CATEGORY Unknown = FromString("unknown");
+    public static readonly CATEGORY Water = FromString("water");
 }


### PR DESCRIPTION


## Changelog

### Bug Fixes

- Updated priorities of widget/components fixing #398 (Should be removed from final changelog as it was caused from previous pr)
- fixed new categories not being loaded because of a bug in  `CATEGORY::AddNewCategory`.

### Tile Tracker Changes

- Retrieve tile information on maps via `TileDesc` tile property. This property can be used in custom maps to describe undetected tiles.

### Misc

- Exposed `PrimaryInfoKey` to the public api. This can be used in custom menus to speak extra info on key press for 3rd party mods.
