### PR TITLE
1.6.15 load menu hotfix

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- Fix LoadGameMenu keyboard navigation broken by Stardew Valley 1.6.15 update.
+- Fix keyboard navigation breaks after clicking any back button from a submenu of title screen, such as Load Game or New Game menus.
 
 ### Tile Tracker Changes
 
@@ -23,4 +25,5 @@
 
 ### Development Chores
 
+- General code cleanup
 

--- a/stardew-access/Commands/CommandManager.cs
+++ b/stardew-access/Commands/CommandManager.cs
@@ -54,12 +54,12 @@ public class CommandManager
     public static void RegisterAll(IModHelper modHelper)
     {
         Type[] CommandsGroups =
-        {
+        [
             typeof(ReadTileCommands),
             typeof(TileMarkingCommands),
             typeof(OtherCommands),
             typeof(RadarCommands),
-        };
+        ];
 
         foreach (var commandsGroup in CommandsGroups)
         {

--- a/stardew-access/Features/TileViewer/TileInfoMenu.cs
+++ b/stardew-access/Features/TileViewer/TileInfoMenu.cs
@@ -11,7 +11,7 @@ using StardewValley.Menus;
 
 namespace stardew_access.Features;
 
-public class TileInfoMenu(int tileX, int tileY) : DialogueBox("", new Response[] { MarkTileResponse, AddToUserTilesResponse, SpeakDetailedInfoResponse })
+public class TileInfoMenu(int tileX, int tileY) : DialogueBox("", [MarkTileResponse, AddToUserTilesResponse, SpeakDetailedInfoResponse])
 {
     private const string MarkTileI18NKey = "menu-tile_info-mark_tile";
     private static readonly Response MarkTileResponse = new(MarkTileI18NKey,
@@ -65,10 +65,10 @@ public class TileInfoMenu(int tileX, int tileY) : DialogueBox("", new Response[]
                     if (UserTilesUtils.TryAndGetTileDataAt(out AccessibleTile.JsonSerializerFormat? tileData, _tileX, _tileY))
                     {
                         _tempDefaultData = tileData;
-                        responses = new Response[]
-                        {
+                        responses =
+                        [
                         EditExistingResponse, DeleteExistingResponse
-                        };
+                        ];
                         selectedResponse = 0;
                         dialogues =
                         [

--- a/stardew-access/Patches/BundleMenuPatches/JojaCDMenuPatch.cs
+++ b/stardew-access/Patches/BundleMenuPatches/JojaCDMenuPatch.cs
@@ -12,7 +12,7 @@ namespace stardew_access.Patches
         {
             harmony.Patch(
                 original: AccessTools.Method(typeof(JojaCDMenu), nameof(JojaCDMenu.draw),
-                    new Type[] { typeof(SpriteBatch) }),
+                    [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(JojaCDMenuPatch), nameof(JojaCDMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/DonationMenuPatches/FieldOfficeMenuPatch.cs
+++ b/stardew-access/Patches/DonationMenuPatches/FieldOfficeMenuPatch.cs
@@ -13,7 +13,7 @@ namespace stardew_access.Patches
         {
             harmony.Patch(
                 original: AccessTools.Method(typeof(FieldOfficeMenu), nameof(FieldOfficeMenu.draw),
-                    new Type[] { typeof(SpriteBatch) }),
+                    [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(FieldOfficeMenuPatch), nameof(FieldOfficeMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/IConditionalPatch.cs
+++ b/stardew-access/Patches/IConditionalPatch.cs
@@ -1,0 +1,8 @@
+using StardewModdingAPI;
+
+ namespace stardew_access.Patches;
+
+internal interface IConditionalPatch : IPatch
+{
+    bool ShouldApply(IModHelper helper);
+}

--- a/stardew-access/Patches/MenuWithInventoryPatches/ForgeMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ForgeMenuPatch.cs
@@ -11,7 +11,7 @@ internal class ForgeMenuPatch : IPatch
     public void Apply(Harmony harmony)
     {
         harmony.Patch(
-            original: AccessTools.Method(typeof(ForgeMenu), nameof(ForgeMenu.draw), new Type[] { typeof(SpriteBatch) }),
+            original: AccessTools.Method(typeof(ForgeMenu), nameof(ForgeMenu.draw), [typeof(SpriteBatch)]),
             postfix: new HarmonyMethod(typeof(ForgeMenuPatch), nameof(ForgeMenuPatch.DrawPatch))
         );
     }

--- a/stardew-access/Patches/MenuWithInventoryPatches/ItemGrabMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ItemGrabMenuPatch.cs
@@ -12,7 +12,7 @@ namespace stardew_access.Patches
         {
             harmony.Patch(
                 original: AccessTools.Method(typeof(ItemGrabMenu), nameof(ItemGrabMenu.draw),
-                    new Type[] { typeof(SpriteBatch) }),
+                    [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(ItemGrabMenuPatch), nameof(ItemGrabMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/MenuWithInventoryPatches/TailoringMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/TailoringMenuPatch.cs
@@ -11,7 +11,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(TailoringMenu), nameof(TailoringMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(TailoringMenu), nameof(TailoringMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(TailoringMenuPatch), nameof(TailoringMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/MiscPatches/IClickableMenuPatch.cs
+++ b/stardew-access/Patches/MiscPatches/IClickableMenuPatch.cs
@@ -201,6 +201,8 @@ internal class IClickableMenuPatch : IPatch
     {
         var activeMenu = Game1.activeClickableMenu;
 
+        if (activeMenu == null) return null;
+
         if (activeMenu.GetParentMenu() != null)
         {
             // To let the parent menu's draw() call set `activeMenu` to the child menu, in the next if condition.
@@ -307,6 +309,7 @@ internal class IClickableMenuPatch : IPatch
 
     private static bool ReceiveKeyPressPatch(IClickableMenu __instance, ref Keys key)
     {
+        if (__instance == null) return true;
         var activeMenu = GetActiveMenu();
                 return activeMenu switch
         {

--- a/stardew-access/Patches/MiscPatches/TextEntryMenuPatch.cs
+++ b/stardew-access/Patches/MiscPatches/TextEntryMenuPatch.cs
@@ -10,7 +10,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                    original: AccessTools.Method(typeof(TextEntryMenu), nameof(TextEntryMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                    original: AccessTools.Method(typeof(TextEntryMenu), nameof(TextEntryMenu.draw), [typeof(SpriteBatch)]),
                     prefix: new HarmonyMethod(typeof(TextEntryMenuPatch), nameof(TextEntryMenuPatch.DrawPatch))
             );
 

--- a/stardew-access/Patches/OtherMenuPatches/AnimalQueryMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/AnimalQueryMenuPatch.cs
@@ -17,7 +17,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(AnimalQueryMenu), nameof(AnimalQueryMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(AnimalQueryMenu), nameof(AnimalQueryMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(AnimalQueryMenuPatch), nameof(AnimalQueryMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/ChooseFromListMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/ChooseFromListMenuPatch.cs
@@ -10,7 +10,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(ChooseFromListMenu), nameof(ChooseFromListMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(ChooseFromListMenu), nameof(ChooseFromListMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(ChooseFromListMenuPatch), nameof(ChooseFromListMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/ConfirmationDialogMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/ConfirmationDialogMenuPatch.cs
@@ -10,7 +10,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(ConfirmationDialog), nameof(ConfirmationDialog.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(ConfirmationDialog), nameof(ConfirmationDialog.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(ConfirmationDialogMenuPatch), nameof(ConfirmationDialogMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/DialogueBoxPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/DialogueBoxPatch.cs
@@ -14,7 +14,7 @@ internal class DialogueBoxPatch : IPatch
     {
         harmony.Patch(
             original: AccessTools.Method(typeof(DialogueBox), nameof(DialogueBox.draw),
-                new Type[] { typeof(SpriteBatch) }),
+                [typeof(SpriteBatch)]),
             postfix: new HarmonyMethod(typeof(DialogueBoxPatch), nameof(DialogueBoxPatch.DrawPatch))
         );
     }

--- a/stardew-access/Patches/OtherMenuPatches/ItemListMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/ItemListMenuPatch.cs
@@ -11,7 +11,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(ItemListMenu), nameof(ItemListMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(ItemListMenu), nameof(ItemListMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(ItemListMenuPatch), nameof(ItemListMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/LevelUpMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/LevelUpMenuPatch.cs
@@ -11,7 +11,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(LevelUpMenu), nameof(LevelUpMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(LevelUpMenu), nameof(LevelUpMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(LevelUpMenuPatch), nameof(LevelUpMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/NumberSelectionMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/NumberSelectionMenuPatch.cs
@@ -15,7 +15,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(NumberSelectionMenu), nameof(NumberSelectionMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(NumberSelectionMenu), nameof(NumberSelectionMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(NumberSelectionMenuPatch), nameof(NumberSelectionMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/PondQuerMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/PondQuerMenuPatch.cs
@@ -14,7 +14,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(PondQueryMenu), nameof(PondQueryMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(PondQueryMenu), nameof(PondQueryMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(PondQueryMenuPatch), nameof(PondQueryMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/OtherMenuPatches/TitleTextInputMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/TitleTextInputMenuPatch.cs
@@ -10,7 +10,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(TitleTextInputMenu), nameof(TitleTextInputMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(TitleTextInputMenu), nameof(TitleTextInputMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(TitleTextInputMenuPatch), nameof(TitleTextInputMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/QuestPatches/BillboardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/BillboardPatch.cs
@@ -12,7 +12,7 @@ internal class BillboardPatch : IPatch
     {
         harmony.Patch(
             original: AccessTools.Method(typeof(Billboard), nameof(Billboard.draw),
-                new Type[] { typeof(SpriteBatch) }),
+                [typeof(SpriteBatch)]),
             postfix: new HarmonyMethod(typeof(BillboardPatch), nameof(BillboardPatch.DrawPatch))
         );
     }

--- a/stardew-access/Patches/QuestPatches/QuestLogPatch.cs
+++ b/stardew-access/Patches/QuestPatches/QuestLogPatch.cs
@@ -18,7 +18,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(QuestLog), nameof(QuestLog.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(QuestLog), nameof(QuestLog.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(QuestLogPatch), nameof(QuestLogPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
@@ -12,7 +12,7 @@ internal class SpecialOrdersBoardPatch : IPatch
     public void Apply(Harmony harmony)
     {
         harmony.Patch(
-                original: AccessTools.Method(typeof(SpecialOrdersBoard), nameof(SpecialOrdersBoard.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(SpecialOrdersBoard), nameof(SpecialOrdersBoard.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(SpecialOrdersBoardPatch), nameof(SpecialOrdersBoardPatch.DrawPatch))
         );
     }

--- a/stardew-access/Patches/TitleMenuPatches/AdvancedGameOptionsPatch.cs
+++ b/stardew-access/Patches/TitleMenuPatches/AdvancedGameOptionsPatch.cs
@@ -12,7 +12,7 @@ internal class AdvancedGameOptionsPatch : IPatch
     {
         harmony.Patch(
             original: AccessTools.DeclaredMethod(typeof(AdvancedGameOptions), nameof(AdvancedGameOptions.draw),
-                new Type[] { typeof(SpriteBatch) }),
+                [typeof(SpriteBatch)]),
             postfix: new HarmonyMethod(typeof(AdvancedGameOptionsPatch), nameof(DrawPatch))
         );
 

--- a/stardew-access/Patches/TitleMenuPatches/CharacterCustomizationMenuPatch.cs
+++ b/stardew-access/Patches/TitleMenuPatches/CharacterCustomizationMenuPatch.cs
@@ -40,7 +40,7 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(CharacterCustomization), nameof(CharacterCustomization.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(CharacterCustomization), nameof(CharacterCustomization.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(CharacterCustomizationMenuPatch), nameof(CharacterCustomizationMenuPatch.DrawPatch))
             );
         }

--- a/stardew-access/Patches/TitleMenuPatches/CoopMenuPatch.cs
+++ b/stardew-access/Patches/TitleMenuPatches/CoopMenuPatch.cs
@@ -12,17 +12,17 @@ namespace stardew_access.Patches
         public void Apply(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(CoopMenu), nameof(CoopMenu.update), new Type[] { typeof(GameTime) }),
+                original: AccessTools.Method(typeof(CoopMenu), nameof(CoopMenu.update), [typeof(GameTime)]),
                 postfix: new HarmonyMethod(typeof(CoopMenuPatch), nameof(UpdatePatch))
             );
 
             harmony.Patch(
-                original: AccessTools.Method(typeof(CoopMenu).GetNestedType("LabeledSlot", BindingFlags.NonPublic | BindingFlags.Instance), "Draw", new Type[] { typeof(SpriteBatch), typeof(int) }),
+                original: AccessTools.Method(typeof(CoopMenu).GetNestedType("LabeledSlot", BindingFlags.NonPublic | BindingFlags.Instance), "Draw", [typeof(SpriteBatch), typeof(int)]),
                 postfix: new HarmonyMethod(typeof(CoopMenuPatch), nameof(LabeledSlot_DrawPatch))
             );
 
             harmony.Patch(
-                original: AccessTools.Method(typeof(CoopMenu).GetNestedType("FriendFarmSlot", BindingFlags.NonPublic | BindingFlags.Instance), "Draw", new Type[] { typeof(SpriteBatch), typeof(int) }),
+                original: AccessTools.Method(typeof(CoopMenu).GetNestedType("FriendFarmSlot", BindingFlags.NonPublic | BindingFlags.Instance), "Draw", [typeof(SpriteBatch), typeof(int)]),
                 postfix: new HarmonyMethod(typeof(CoopMenuPatch), nameof(FriendFarmSlot_DrawPatch))
             );
         }

--- a/stardew-access/Patches/TitleMenuPatches/LoadGameMenuPatch.cs
+++ b/stardew-access/Patches/TitleMenuPatches/LoadGameMenuPatch.cs
@@ -1,129 +1,165 @@
 using HarmonyLib;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using stardew_access.Translation;
 using StardewValley;
 using StardewValley.Menus;
 using static StardewValley.Menus.LoadGameMenu;
 
-namespace stardew_access.Patches
+namespace stardew_access.Patches;
+
+internal class LoadGameMenuPatch : IPatch
 {
-    internal class LoadGameMenuPatch : IPatch
+    private static bool firstTimeInMenu = true;
+
+    public void Apply(Harmony harmony)
     {
-        private static bool firstTimeInMenu = true;
+        harmony.Patch(
+            original: AccessTools.Method(typeof(LoadGameMenu.SaveFileSlot), nameof(LoadGameMenu.SaveFileSlot.Draw), [typeof(SpriteBatch), typeof(int)]),
+            postfix: new HarmonyMethod(typeof(LoadGameMenuPatch), nameof(LoadGameMenuPatch.DrawPatch))
+        );
+    }
 
-        public void Apply(Harmony harmony)
+    private static void DrawPatch(SaveFileSlot __instance, LoadGameMenu ___menu, int i)
+    {
+        try
         {
-            harmony.Patch(
-                original: AccessTools.Method(typeof(LoadGameMenu.SaveFileSlot), nameof(LoadGameMenu.SaveFileSlot.Draw), new Type[] { typeof(SpriteBatch), typeof(int) }),
-                postfix: new HarmonyMethod(typeof(LoadGameMenuPatch), nameof(LoadGameMenuPatch.DrawPatch))
-            );
+            int x = Game1.getMouseX(true), y = Game1.getMouseY(true);
+
+            if (NarrateHoveredButtons(__instance, ___menu, x, y, i))
+            {
+                return;
+            }
+
+            if (NarrateDeleteConfirmationMenu(___menu, x, y))
+            {
+                return;
+            }
+
+            NarrateFarmButton(__instance, ___menu, x, y, i);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"An error occurred in load game menu patch:\n{e.Message}\n{e.StackTrace}");
+        }
+    }
+
+    private static bool NarrateDeleteConfirmationMenu(LoadGameMenu ___menu, int x, int y)
+    {
+        if (!___menu.deleteConfirmationScreen)
+        {
+            firstTimeInMenu = true;
+            return false;
         }
 
-        private static void DrawPatch(SaveFileSlot __instance, LoadGameMenu ___menu, int i)
+        string translationKey = "";
+        if (firstTimeInMenu)
         {
-            try
-            {
-                int x = Game1.getMouseX(true), y = Game1.getMouseY(true);
-
-                if (NarrateHoveredButtons(__instance, ___menu, x, y, i))
-                {
-                    return;
-                }
-
-                if (NarrateDeleteConfirmationMenu(___menu, x, y))
-                {
-                    return;
-                }
-
-                NarrateFarmButton(__instance, ___menu, x, y, i);
-            }
-            catch (Exception e)
-            {
-                Log.Error($"An error occurred in load game menu patch:\n{e.Message}\n{e.StackTrace}");
-            }
+            firstTimeInMenu = false;
+            MainClass.ScreenReader.MenuPrefixNoQueryText = Translator.Instance.Translate("menu-load_game-delete_farm_confirmation_text", TranslationCategory.Menu) + " ";
         }
 
-        private static bool NarrateDeleteConfirmationMenu(LoadGameMenu ___menu, int x, int y)
+        if (___menu.okDeleteButton.containsPoint(x, y))
         {
-            if (!___menu.deleteConfirmationScreen)
-            {
-                firstTimeInMenu = true;
-                return false;
-            }
-
-            string translationKey = "";
-            if (firstTimeInMenu)
-            {
-                firstTimeInMenu = false;
-                MainClass.ScreenReader.MenuPrefixNoQueryText = Translator.Instance.Translate("menu-load_game-delete_farm_confirmation_text", TranslationCategory.Menu) + " ";
-            }
-
-            if (___menu.okDeleteButton.containsPoint(x, y))
-            {
-                translationKey = "common-ui-ok_button";
-            }
-            else if (___menu.cancelDeleteButton.containsPoint(x, y))
-            {
-                translationKey = "common-ui-cancel_button";
-            }
-
-            MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true);
-            return true;
+            translationKey = "common-ui-ok_button";
+        }
+        else if (___menu.cancelDeleteButton.containsPoint(x, y))
+        {
+            translationKey = "common-ui-cancel_button";
         }
 
-        private static void NarrateFarmButton(SaveFileSlot __instance, LoadGameMenu ___menu, int x, int y, int i)
+        MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true);
+        return true;
+    }
+
+    private static void NarrateFarmButton(SaveFileSlot __instance, LoadGameMenu ___menu, int x, int y, int i)
+    {
+        if (!___menu.slotButtons[i].containsPoint(x, y)) return;
+        if (__instance.Farmer == null) return;
+
+        string dateStringForSaveGame = (!__instance.Farmer.dayOfMonthForSaveGame.HasValue ||
+            !__instance.Farmer.seasonForSaveGame.HasValue ||
+            !__instance.Farmer.yearForSaveGame.HasValue) ? __instance.Farmer.dateStringForSaveGame : Utility.getDateStringFor(__instance.Farmer.dayOfMonthForSaveGame.Value, __instance.Farmer.seasonForSaveGame.Value, __instance.Farmer.yearForSaveGame.Value);
+
+        string translationKey = "menu-load_game-farm_details";
+        object translationTokens = new
         {
-            if (!___menu.slotButtons[i].containsPoint(x, y)) return;
-            if (__instance.Farmer == null) return;
+            index = (TitleMenu.subMenu as LoadGameMenu)?.currentItemIndex + i + 1 ?? i + 1,
+            farm_name = __instance.Farmer.farmName.Value,
+            farmer_name = __instance.Farmer.isCustomized.Value
+                            ? __instance.Farmer.displayName
+                            : Game1.content.LoadString("Strings\\UI:CoopMenu_NewFarmhand"),
+            money = __instance.Farmer.Money.ToString(),
+            hours_played = Utility.getHoursMinutesStringFromMilliseconds(__instance.Farmer.millisecondsPlayed),
+            date = dateStringForSaveGame
+        };
 
-            string dateStringForSaveGame = (!__instance.Farmer.dayOfMonthForSaveGame.HasValue ||
-                !__instance.Farmer.seasonForSaveGame.HasValue ||
-                !__instance.Farmer.yearForSaveGame.HasValue) ? __instance.Farmer.dateStringForSaveGame : Utility.getDateStringFor(__instance.Farmer.dayOfMonthForSaveGame.Value, __instance.Farmer.seasonForSaveGame.Value, __instance.Farmer.yearForSaveGame.Value);
+        MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true, translationTokens);
+    }
 
-            string translationKey = "menu-load_game-farm_details";
-            object translationTokens = new
+    private static bool NarrateHoveredButtons(SaveFileSlot __instance, LoadGameMenu ___menu, int x, int y, int i)
+    {
+        string translationKey;
+        object? translationTokens = null;
+
+        if (___menu.deleteButtons.Count > 0 && ___menu.deleteButtons[i].containsPoint(x, y))
+        {
+            translationKey = "menu-load_game-delete_farm_button";
+            translationTokens = new
             {
-                index = (TitleMenu.subMenu as LoadGameMenu)?.currentItemIndex + i + 1 ?? i + 1,
-                farm_name = __instance.Farmer.farmName.Value,
-                farmer_name = __instance.Farmer.isCustomized.Value
-                                ? __instance.Farmer.displayName
-                                : Game1.content.LoadString("Strings\\UI:CoopMenu_NewFarmhand"),
-                money = __instance.Farmer.Money.ToString(),
-                hours_played = Utility.getHoursMinutesStringFromMilliseconds(__instance.Farmer.millisecondsPlayed),
-                date = dateStringForSaveGame
+                name = __instance.Farmer.farmName.Value
             };
-
-            MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true, translationTokens);
         }
-
-        private static bool NarrateHoveredButtons(SaveFileSlot __instance, LoadGameMenu ___menu, int x, int y, int i)
+        else if (___menu.upArrow != null && ___menu.upArrow.containsPoint(x, y))
         {
-            string translationKey;
-            object? translationTokens = null;
-
-            if (___menu.deleteButtons.Count > 0 && ___menu.deleteButtons[i].containsPoint(x, y))
-            {
-                translationKey = "menu-load_game-delete_farm_button";
-                translationTokens = new
-                {
-                    name = __instance.Farmer.farmName.Value
-                };
-            }
-            else if (___menu.upArrow != null && ___menu.upArrow.containsPoint(x, y))
-            {
-                translationKey = "common-ui-scroll_up_button";
-            }
-            else if (___menu.downArrow != null && ___menu.downArrow.containsPoint(x, y))
-            {
-                translationKey = "common-ui-scroll_down_button";
-            }
-            else
-            {
-                return false;
-            }
-
-            MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true, translationTokens);
-            return true;
+            translationKey = "common-ui-scroll_up_button";
         }
+        else if (___menu.downArrow != null && ___menu.downArrow.containsPoint(x, y))
+        {
+            translationKey = "common-ui-scroll_down_button";
+        }
+        else
+        {
+            return false;
+        }
+
+        MainClass.ScreenReader.TranslateAndSayWithMenuChecker(translationKey, true, translationTokens);
+        return true;
+    }
+
+    private static void SetFocusIfNeeded(LoadGameMenu __instance)
+    {
+        if (__instance.currentlySnappedComponent == null
+                || (__instance.currentlySnappedComponent.myID == LoadGameMenu.region_cancelDelete || __instance.currentlySnappedComponent.myID == LoadGameMenu.region_okDelete)
+        )
+        {
+            __instance.currentlySnappedComponent = __instance.getComponentWithID(__instance.currentItemIndex);
+            __instance.snapCursorToCurrentSnappedComponent();
+        }
+    }
+
+    private static void SetConfirmationDialogFocusIfNeeded(LoadGameMenu __instance)
+    {
+        var currentlySnappedComponent = __instance.currentlySnappedComponent;
+        var componentID = currentlySnappedComponent?.myID ?? -1;
+        if (currentlySnappedComponent == null
+                || !(componentID == LoadGameMenu.region_okDelete || componentID == LoadGameMenu.region_cancelDelete))
+        {
+            __instance.snapToDefaultClickableComponent();
+            componentID = currentlySnappedComponent?.myID ?? LoadGameMenu.region_cancelDelete;
+        }
+    }
+
+    internal static bool ReceiveKeyPressPatch(LoadGameMenu __instance, ref Keys key)
+    {
+        if (!__instance.deleteConfirmationScreen)
+        {
+            SetFocusIfNeeded(__instance);
+        }
+        else
+        {
+            SetConfirmationDialogFocusIfNeeded(__instance);
+        }
+        return IClickableMenuPatch.HandleMenuMovementKeyPress(__instance, ref key);
     }
 }

--- a/stardew-access/Patches/TitleMenuPatches/TitleMenuPatch.cs
+++ b/stardew-access/Patches/TitleMenuPatches/TitleMenuPatch.cs
@@ -118,5 +118,7 @@ internal class TitleMenuPatch : IPatch
     private static void ReturnToMainTitleScreenPatch()
     {
         shouldSnapToDefault = true;
+        Game1.options.setGamepadMode("force_on");
+        Game1.options.snappyMenus = true;
     }
 }

--- a/stardew-access/Patches/TitleMenuPatches/TitleMenuPatch.cs
+++ b/stardew-access/Patches/TitleMenuPatches/TitleMenuPatch.cs
@@ -9,11 +9,16 @@ namespace stardew_access.Patches;
 internal class TitleMenuPatch : IPatch
 {
     private static bool HasSpokenSkipMessage = false;
+    private static bool shouldSnapToDefault = false;
     public void Apply(Harmony harmony)
     {
         harmony.Patch(
-                original: AccessTools.Method(typeof(TitleMenu), nameof(TitleMenu.draw), new Type[] { typeof(SpriteBatch) }),
+                original: AccessTools.Method(typeof(TitleMenu), nameof(TitleMenu.draw), [typeof(SpriteBatch)]),
                 postfix: new HarmonyMethod(typeof(TitleMenuPatch), nameof(TitleMenuPatch.DrawPatch))
+        );
+        harmony.Patch(
+                original: AccessTools.Method(typeof(TitleMenu), nameof(TitleMenu.ReturnToMainTitleScreen)),
+                postfix: new HarmonyMethod(typeof(TitleMenuPatch), nameof(TitleMenuPatch.ReturnToMainTitleScreenPatch))
         );
     }
 
@@ -23,6 +28,13 @@ internal class TitleMenuPatch : IPatch
         {
             if (___isTransitioningButtons)
                 return;
+
+            if (shouldSnapToDefault)
+            {
+                __instance.populateClickableComponentList();
+                __instance.snapToDefaultClickableComponent();
+                shouldSnapToDefault = false;
+            }
 
             int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
             string translationKey = "";
@@ -102,4 +114,9 @@ internal class TitleMenuPatch : IPatch
         "invite" => "menu-title-invite_button",
         _ => ""
     };
+
+    private static void ReturnToMainTitleScreenPatch()
+    {
+        shouldSnapToDefault = true;
+    }
 }


### PR DESCRIPTION
Changes in 1.6.15 broke keyboard navigation in the LoadGameMenu as well as everywhere after clicking the back button. Added prefix harmony patch to capture appropriate navigation keys and handle keyboard nav ourselves for LoadGameMenu. Infrastructure exists to extend support to any other menu class lacking keyboard navigation.
New postfix patch handles re-enabling gamepad mode after clicking the back button which fixes the breaking keyboard nav after going back to title.

## Changelog

### New Features


### Feature Updates


### Bug Fixes

- Fix LoadGameMenu keyboard navigation broken by Stardew Valley 1.6.15 update.
- Fix keyboard navigation breaks after clicking any back button from a submenu of title screen, such as Load Game or New Game menus.

### Tile Tracker Changes


### Guides And Docs


### Misc


### Translation Changes


### Development Chores

- General code cleanup

