### PR TITLE
Fix SocialPagePatch Reading Translation Tokens

### DIFF
--- a/stardew-access/Patches/GameMenuPatches/SocialPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/SocialPagePatch.cs
@@ -71,14 +71,14 @@ internal class SocialPagePatch : IPatch
         {
             if (datable || housemate)
             {
-                relationship_status = ((!Game1.content.ShouldUseGenderedCharacterTranslations()) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11635") : ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11635").Split('/')[0] : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11635").Split('/').Last()));
+                relationship_status = ((!Game1.content.ShouldUseGenderedCharacterTranslations()) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Single_Female") : ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Single_Female").Split('/')[0] : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Single_Female").Split('/').Last()));
                 if (housemate)
                 {
                     relationship_status = Game1.content.LoadString("Strings\\StringsFromCSFiles:Housemate");
                 }
                 else if (isCurrentSpouse)
                 {
-                    relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11636") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11637"));
+                    relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Husband") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Wife"));
                 }
                 else if (entry.IsMarriedToAnyone())
                 {
@@ -86,31 +86,31 @@ internal class SocialPagePatch : IPatch
                 }
                 else if (!Game1.player.isMarriedOrRoommates() && isDating)
                 {
-                    relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11639") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11640"));
+                    relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Boyfriend") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Girlfriend"));
                 }
                 else if (entry.IsDivorcedFromCurrentPlayer())
                 {
-                    relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11642") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11643"));
+                    relationship_status =((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_ExHusband") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_ExWife"));
                 }
             }
         } else {
             Farmer farmer = (Farmer)entry.Character;
-            relationship_status = ((!Game1.content.ShouldUseGenderedCharacterTranslations()) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11635") : ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11635").Split('/')[0] : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11635").Split('/').Last()));
+            relationship_status = ((!Game1.content.ShouldUseGenderedCharacterTranslations()) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Single_Female") : ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Single_Female").Split('/')[0] : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Single_Female").Split('/').Last()));
             if (isCurrentSpouse)
             {
-                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11636") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11637"));
+                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Husband") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Wife"));
             }
             else if (farmer.isMarriedOrRoommates() && !farmer.hasRoommate())
             {
-                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\UI:SocialPage_MarriedToOtherPlayer_MaleNPC") : Game1.content.LoadString("Strings\\UI:SocialPage_MarriedToOtherPlayer_FemaleNPC"));
+                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\UI:SocialPage_Relationship_MarriedToOtherPlayer_MaleNpc") : Game1.content.LoadString("Strings\\UI:SocialPage_Relationship_MarriedToOtherPlayer_FemaleNpc"));
             }
             else if (!Game1.player.isMarriedOrRoommates() && entry.IsDatingCurrentPlayer())
             {
-                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11639") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11640"));
+                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Boyfriend") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_Girlfriend"));
             }
             else if (entry.IsDivorcedFromCurrentPlayer())
             {
-                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11642") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage.cs.11643"));
+                relationship_status = ((gender == Gender.Male) ? Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_ExHusband") : Game1.content.LoadString("Strings\\StringsFromCSFiles:SocialPage_Relationship_ExWife"));
             }
         }
         return !String.IsNullOrWhiteSpace(relationship_status) ? relationship_status : null;


### PR DESCRIPTION
SocialPagePatch was leaking translation tokens for an npc's relationship status due to upstream changes. Solved by updating to new strings.
Fixes khanshoaib3/stardew-access#431

[//]: # (A few things to note:)
[//]: # (1. The changelogs will be automatically added to `docs/changelogs/latest.md` by the fast-forward workflow)
[//]: # (2. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (3. Do not change the heading names and/or the heading levels)
[//]: # (4. Remove the unwanted changelog sections)


## Changelog

### New Features


### Feature Updates


### Bug Fixes

Fix social page reading translation tokens instead of marriageable npc's relationship status.

### Tile Tracker Changes


### Guides And Docs


### Misc


### Translation Changes


### Development Chores


