### PR TITLE
ObjectTracker auto refresh fixed

### DIFF
--- a/stardew-access/Features/ObjectTracker.cs
+++ b/stardew-access/Features/ObjectTracker.cs
@@ -195,7 +195,7 @@ internal class ObjectTracker : FeatureBase
             if (countHasChanged)
             {
                 Log.Debug("Refreshing ObjectTracker; changes detected.");
-                GetLocationObjects(resetFocus: false);
+                GetLocationObjects(resetFocus: SortByProximity);
                 countHasChanged = false;  // Reset the flag for the next cycle
             }
 
@@ -240,6 +240,7 @@ internal class ObjectTracker : FeatureBase
         FixCharacterMovement();
         if (lastTargetedTile != null) FacePlayerToTargetTile(lastTargetedTile.Value);
         ReadCurrentlySelectedObject();
+        GetLocationObjects(resetFocus: SortByProximity);
         pathfinder?.Dispose();
     }
 

--- a/stardew-access/Features/ObjectTracker.cs
+++ b/stardew-access/Features/ObjectTracker.cs
@@ -91,7 +91,7 @@ internal class ObjectTracker : FeatureBase
         // The event with id 13 is the Haley's six heart event, the one at the beach requiring the player to find the bracelet
         // *** Exiting here will cause GridMovement and ObjectTracker functionality to not work during this event, making the bracelet impossible to track ***
         if (!Context.IsPlayerFree && !(Game1.CurrentEvent is not null && Game1.CurrentEvent.id == "13"))
-            return;
+            return; // so ... why are we exiting here? _^_
 
         if (Game1.activeClickableMenu != null && pathfinder != null && pathfinder.IsActive)
         {
@@ -103,7 +103,7 @@ internal class ObjectTracker : FeatureBase
             return;
         }
 
-        if (!e.IsMultipleOf(15) || !MainClass.Config.OTAutoRefreshing) return;
+        if (!e.IsMultipleOf(15));
 
         Tick();
     }
@@ -177,7 +177,7 @@ internal class ObjectTracker : FeatureBase
 
     public void Tick()
     {
-        if (MainClass.Config.OTAutoRefreshing || Game1.currentLocation == null) return;
+        if (!MainClass.Config.OTAutoRefreshing || Game1.currentLocation == null) return;
 
         if (updateActions.Count == 0)
         {


### PR DESCRIPTION
[//]: # (A few things to note:)
[//]: # (1. The changelogs will be automatically added to `docs/changelogs/latest.md` by the fast-forward workflow)
[//]: # (2. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (3. Do not change the heading names and/or the heading levels)
[//]: # (4. Remove the unwanted changelog sections)

It was a missing `!` this entire time ... 🤦🏼‍♀️
## Changelog

Fixed ObjectTracker autorefresh. It now refreshes as intended without the user constantly having to manually update it by tracking something.
Improved to retain focus on nearest item when in proximity sort mode.

### New Features


### Feature Updates

When "Sort By Proximity" is enabled, the ObjectTracker will focus on the closest item after map updates. E.G., after harvesting a specific crop, focus moves to the next closest crop, rather than the next closest crop of the same kind. Sorting alphabetically retains the old behavior.

### Bug Fixes

ObjectTracker autorefresh is fixed! No more mashing the home button to force a refresh.

### Tile Tracker Changes


### Guides And Docs


### Misc


### Translation Changes


### Development Chores


