### PR TITLE
Fixed Garden Pot Categories

### DIFF
--- a/stardew-access/Utils/TileInfo.cs
+++ b/stardew-access/Utils/TileInfo.cs
@@ -12,6 +12,7 @@ using StardewValley.Monsters;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
 using StardewValley.TokenizableStrings;
+using System.ComponentModel;
 
 namespace stardew_access.Utils;
 
@@ -717,10 +718,30 @@ public class TileInfo
         }
         else if (obj is IndoorPot indoorPot)
         {
-            string? potContent = indoorPot.bush.Value != null
-                ? TerrainUtils.GetBushInfoString(indoorPot.bush.Value)
-                : TerrainUtils.GetDirtInfoString(indoorPot.hoeDirt.Value, true);
+            string? potContent;
+            CATEGORY potCategory = CATEGORY.Pending;
+            if (indoorPot.bush.Value != null)
+            {
+                // this branch is followed only when a tea bush has been planted in a pot.
+                potContent = TerrainUtils.GetBushInfoString(indoorPot.bush.Value);
+                potCategory = TerrainUtils.GetBushInfo(indoorPot.bush.Value).IsHarvestable
+                    ? CATEGORY.Ready
+                    : CATEGORY.Bushes;
+            }
+            else
+            {
+                potContent = TerrainUtils.GetDirtInfoString(indoorPot.hoeDirt.Value, true);
+                if (TerrainUtils.GetDirtInfo(indoorPot.hoeDirt.Value).IsReadyForHarvest)
+                {
+                    potCategory = CATEGORY.Ready;
+                }
+                else if (TerrainUtils.GetDirtInfo(indoorPot.hoeDirt.Value).IsWatered && TerrainUtils.GetDirtInfo(indoorPot.hoeDirt.Value).CropType != null)
+                {
+                    potCategory = CATEGORY.Crops;
+                }
+            }
             toReturn.name = $"{obj.DisplayName}, {potContent}";
+            toReturn.category = potCategory;
         }
         else if (obj is Sign sign && sign.displayItem.Value != null)
         {


### PR DESCRIPTION
Garden pots will now appear in the correct categories when they hold crops or bushes.
Fixes khanshoaib3/stardew-access#434

[//]: # (A few things to note:)
[//]: # (1. The changelogs will be automatically added to `docs/changelogs/latest.md` by the fast-forward workflow)
[//]: # (2. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (3. Do not change the heading names and/or the heading levels)
[//]: # (4. Remove the unwanted changelog sections)


## Changelog

### Bug Fixes

Garden Pots have been moved from the "Other" category to the "Pending" category to better reflect their role.
When holding a crop, pots will stay in "Pending" if they are unwatered. They will move to "Crops" once watered.
When holding a bush such as a tea sapling, pots will appear in "Bushes".
When any pot can be harvested, it will appear in "Ready".
