### PR TITLE
Removed Incorrect Door Sound When Changing Maps With Grid Movement On

### DIFF
--- a/stardew-access/Features/GridMovement.cs
+++ b/stardew-access/Features/GridMovement.cs
@@ -234,7 +234,7 @@ internal class GridMovement : FeatureBase
         if (Game1.player.FacingDirection == direction) return false;
 
         Game1.player.faceDirection(direction);
-        Game1.playSound("dwop");
+        // Game1.playSound("dwop");
         is_moving = true;
 
         timer.Start();
@@ -290,7 +290,7 @@ internal class GridMovement : FeatureBase
                 timer.Interval = TimerInterval;
                 timer.Start();
 
-                Game1.playSound("doorOpen");
+                // Game1.playSound("doorOpen");
                 Game1.player.warpFarmer(warp);
                 is_warping = true;
             }
@@ -311,7 +311,7 @@ internal class GridMovement : FeatureBase
             }
             else
             {
-                Game1.playSound("doorClose");
+                // Game1.playSound("doorClose");
             }
         }
     }


### PR DESCRIPTION
The door sound plays when switching between maps while grid movement is enabled even if there is no door. This is undesired and is a result of grid movement being extremely janky in general.

This update restores vanilla behavior so that no sound is played when walking between maps where there is no door, even when grid movement is on.
fixes khanshoaib3/stardew-access#408

[//]: # (A few things to note:)
[//]: # (1. The changelogs will be automatically added to `docs/changelogs/latest.md` by the fast-forward workflow)
[//]: # (2. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (3. Do not change the heading names and/or the heading levels)
[//]: # (4. Remove the unwanted changelog sections)
## Changelog

### Bug Fixes

- Removed incorrect door sound that plays when changing maps with grid movement on even when no door has been passed through.
