### PR TITLE
Fixed Water Crops Appearing in Pending

### DIFF
--- a/stardew-access/Utils/TerrainUtils.cs
+++ b/stardew-access/Utils/TerrainUtils.cs
@@ -233,10 +233,17 @@ public static class TerrainUtils
             case LargeTerrainFeature largeTerrainFeature:
                 return GetTerrainFeatureInfoAndCategory(largeTerrainFeature, ignoreIfEmpty);
             case HoeDirt dirt:
+                // all dirt/crop tiles default to pending
                 CATEGORY cropCategory = CATEGORY.Pending;
+                // if dirt is ready for harvest, move to ready (implicit crop presence check)
                 if (dirt.readyForHarvest())
                 {
                     cropCategory = CATEGORY.Ready;
+                }
+                // if there is a watered crop that is not ready for harvest, move it to crops
+                else if (dirt.isWatered() && dirt.crop != null && !dirt.readyForHarvest())
+                {
+                    cropCategory = CATEGORY.Crops;
                 }
                 return (GetDirtInfoString(dirt, ignoreIfEmpty), cropCategory);
             case CosmeticPlant cosmeticPlant:


### PR DESCRIPTION
[//]: # (A few things to note:)
[//]: # (1. The changelogs will be automatically added to `docs/changelogs/latest.md` by the fast-forward workflow)
[//]: # (2. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (3. Do not change the heading names and/or the heading levels)
[//]: # (4. Remove the unwanted changelog sections)


## Changelog

### Bug Fixes

- Fixed a bug where watered crops would remain in the pending category instead of moving to the crops category.
