### PR TITLE
Patch 1.6.1

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -8,18 +8,27 @@
 
 ### Bug Fixes
 
+- Fixed pet names not speaking.
+- Fixed special orders board speaking incorrect quest status (in progress and completed).
 
 ### Tile Tracker Changes
 
+- Tracked prize ticket box.
+- Renamed special quest board to special orders board.
 
 ### Guides And Docs
 
+- Fixed and updated links (partly done by @BrailleBennett) and table formats (no change visually).
 
 ### Misc
 
 
 ### Translation Changes
 
+- Removed(en.ftl): `tile_name-special_quest_board`
+- New(en.ftl): `tile-town-special_orders_board` = `Special Orders Board`
+- New(en.ftl): `tile-town-prize_ticket_box` = [English Value](https://github.com/khanshoaib3/stardew-access-local/blob/71a69961e52a999e85e647557843f160710a4956/stardew-access/i18n/en.ftl#L250-L254)
+- New(menu.en.ftl): `menu-special_orders_board-no_active_quest` = `No active quest`
 
 ### Development Chores
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,31 +14,31 @@ For a list of SMAPI commands, visit the [Console commands](https://stardewvalley
 
 ## Tile Reader Commands
 
-| Command  | Description                                    |
-|----------|------------------------------------------------|
-| readtile | Toggle Read Tile feature                       |
-| snapmouse  | Toggle Snap Mouse Feature                                        |
-| flooring | Toggle reading flooring                        |
-| watered  | Toggle speaking watered or unwatered for crops |
+| Command    | Description                                    |
+|------------|------------------------------------------------|
+| readtile   | Toggle Read Tile feature                       |
+| snapmouse  | Toggle Snap Mouse Feature                      |
+| flooring   | Toggle reading flooring                        |
+| watered    | Toggle speaking watered or unwatered for crops |
 
 ## Building Commands
 
-| Command   | Description                                                                                         | Special Syntax (If any)                  | Argument details (If any)                                                                                                         | Example      |
-|-----------|-----------------------------------------------------------------------------------------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------|
-| mark      | Marks the player's current position at a specified index                      | mark [Index:number]                      | Index: the desired index to save the position (0 - 9)                                                          | mark 0       |
-| marklist  | List all marked positions                                                                           |                                          |                                                                                                                                   | marklist     |
-| buildlist | List all buildings for selection                                 |                                          |                                                                                                                                   | buildlist    |
-| buildsel  | Select the index of a building to place a farm animal in the desired building                            | buildsel [Index:number]                  | Index: the index of the building we want to select, use buildlist command to list the buildings with their index                  | buildsel 3   |
+| Command   | Description                                                                                          | Special Syntax (If any)                  | Argument details (If any)                                                                                        | Example      |
+|-----------|------------------------------------------------------------------------------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------------|--------------|
+| mark      | Marks the player's current position at a specified index                                             | mark [Index:number]                      | Index: the desired index to save the position (0 - 9)                                                            | mark 0       |
+| marklist  | List all marked positions                                                                            |                                          |                                                                                                                  | marklist     |
+| buildlist | List all buildings for selection                                                                     |                                          |                                                                                                                  | buildlist    |
+| buildsel  | Select the index of a building to place a farm animal in the desired building                        | buildsel [Index:number]                  | Index: the index of the building we want to select, use buildlist command to list the buildings with their index | buildsel 3   |
 
 ## Narration & Verbosity Commands
 
-| Command    | Description                                                      |
-|------------|------------------------------------------------------------------|
+| Command         | Description                                                                                                           |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------|
 | rlt ``<index>`` | Repeats the last phrase narrated. ``<index>`` specifies how many phrases before the latest are skipped when repeating |
-| hnspercent | Toggle between speaking in percentage or full health and stamina |
-| warning    | Toggle warnings feature                                          |
-| tts        | Toggles the screen reader/tts                                    |
-| refsr      | Refreshes screen reader                                          |
+| hnspercent      | Toggle between speaking in percentage or full health and stamina                                                      |
+| warning         | Toggle warnings feature                                                                                               |
+| tts             | Toggles the screen reader/tts                                                                                         |
+| refsr           | Refreshes screen reader                                                                                               |
 
 ## Radar Commands
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -62,94 +62,94 @@ For a full list of key names, refer to the [Key Bindings List](https://stardewva
 
 ## Mouse Sim Keys Config
 
-| Name                   | Default Value       | Description                                 |
-| ---------------------- | ------------------- | ------------------------------------------- |
-| LeftClickMainKey       | LeftControl + Enter | Primary key to simulate mouse left click    |
-| RightClickMainKey      | LeftShift + Enter   | Primary key to simulate mouse right click   |
-| LeftClickAlternateKey  | OemOpenBrackets     | Secondary key to simulate mouse left click  |
-| RightClickAlternateKey | OemCloseBrackets    | Secondary key to simulate mouse right click |
+| Name                    | Default Value        | Description                                  |
+|-------------------------|----------------------|----------------------------------------------|
+| LeftClickMainKey        | LeftControl + Enter  | Primary key to simulate mouse left click     |
+| RightClickMainKey       | LeftShift + Enter    | Primary key to simulate mouse right click    |
+| LeftClickAlternateKey   | OemOpenBrackets      | Secondary key to simulate mouse left click   |
+| RightClickAlternateKey  | OemCloseBrackets     | Secondary key to simulate mouse right click  |
 
 ## Read Tile Configs
 
-| Name                       | Default Value | Description                                                                                       |
-| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------- |
-| ReadTile                   | true          | Toggle `Read Tile` feature                                                                        |
-| ReadTileKey                | J             | Speak the contents of the tile the player is facing                                               |
-| ReadTileDebug              | false         | Sets whether extra debug info is included when reading tile info                                  |
-| ReadStandingTileKey        | LeftAlt + J   | Speak the contents of the tile player is standing on                                              |
-| ReadFlooring               | false         | Toggle reading floorings                                                                          |
-| ReadFlooringKey            | \<unset\>     | Toggles reading floorings, an alternate/companion to `flooring` command.                          |
-| DisableDescriptiveFlooring | false         | Toggle reading descriptive names for flooring or generice ones (pathway/flooring/stepping stone). |
-| WateredToggle              | true          | Toggle speaking watered or unwatered for crops                                                    |
-| ReadTileIndexes            | false         | Toggle speaking tile indexes with other info                                                      |
-| ReadHoedDirtInMineShafts   | false         | Toggle speaking hoed dirt (soil) in mine shafts                                                   |
+| Name                        | Default Value  | Description                                                                                        |
+|-----------------------------|----------------|----------------------------------------------------------------------------------------------------|
+| ReadTile                    | true           | Toggle `Read Tile` feature                                                                         |
+| ReadTileKey                 | J              | Speak the contents of the tile the player is facing                                                |
+| ReadTileDebug               | false          | Sets whether extra debug info is included when reading tile info                                   |
+| ReadStandingTileKey         | LeftAlt + J    | Speak the contents of the tile player is standing on                                               |
+| ReadFlooring                | false          | Toggle reading floorings                                                                           |
+| ReadFlooringKey             | \<unset\>      | Toggles reading floorings, an alternate/companion to `flooring` command.                           |
+| DisableDescriptiveFlooring  | false          | Toggle reading descriptive names for flooring or generice ones (pathway/flooring/stepping stone).  |
+| WateredToggle               | true           | Toggle speaking watered or unwatered for crops                                                     |
+| ReadTileIndexes             | false          | Toggle speaking tile indexes with other info                                                       |
+| ReadHoedDirtInMineShafts    | false          | Toggle speaking hoed dirt (soil) in mine shafts                                                    |
 
 ## Tile Viewer Configs
 
-| Name                              | Default Value       | Description                                                                                         |
-| --------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------- |
-| ToggleRelativeCursorLockKey       | L                   | Toggles relative cursor lock                                                                        |
-| AutoWalkToTileKey                 | LeftControl + Enter | Auto walk to focused tile                                                                           |
-| OpenTileInfoMenuKey               | LeftShift + Enter   | Opens the Tile Info menu for the focused tile                                                       |
-| TileCursorUpKey                   | Up                  | Move the tile cursor one tile up                                                                    |
-| TileCursorRightKey                | Right               | Move the tile cursor one tile right                                                                 |
-| TileCursorDownKey                 | Down                | Move the tile cursor one tile down                                                                  |
-| TileCursorLeftKey                 | Left                | Move the tile cursor one tile left                                                                  |
-| TileCursorPreciseUpKey            | LeftShift + Up      | Move the tile cursor up by a specified pixel value                                                  |
-| TileCursorPreciseRightKey         | LeftShift + Right   | Move the tile cursor right by a specified pixel value                                               |
-| TileCursorPreciseDownKey          | LeftShift + Down    | Move the tile cursor down by a specified pixel value                                                |
-| TileCursorPreciseLeftKey          | LeftShift + Left    | Move the tile cursor left by a specified pixel value                                                |
-| LimitTileCursorToScreen           | false               | Toggles the ability to move the tile cursor beyond the portion of the map that is visible on screen |
-| TileCursorPreciseMovementDistance | 8                   | Specifies how many pixels the cursor should move when using precision tile cursor movement          |
+| Name                               | Default Value        | Description                                                                                          |
+|------------------------------------|----------------------|------------------------------------------------------------------------------------------------------|
+| ToggleRelativeCursorLockKey        | L                    | Toggles relative cursor lock                                                                         |
+| AutoWalkToTileKey                  | LeftControl + Enter  | Auto walk to focused tile                                                                            |
+| OpenTileInfoMenuKey                | LeftShift + Enter    | Opens the Tile Info menu for the focused tile                                                        |
+| TileCursorUpKey                    | Up                   | Move the tile cursor one tile up                                                                     |
+| TileCursorRightKey                 | Right                | Move the tile cursor one tile right                                                                  |
+| TileCursorDownKey                  | Down                 | Move the tile cursor one tile down                                                                   |
+| TileCursorLeftKey                  | Left                 | Move the tile cursor one tile left                                                                   |
+| TileCursorPreciseUpKey             | LeftShift + Up       | Move the tile cursor up by a specified pixel value                                                   |
+| TileCursorPreciseRightKey          | LeftShift + Right    | Move the tile cursor right by a specified pixel value                                                |
+| TileCursorPreciseDownKey           | LeftShift + Down     | Move the tile cursor down by a specified pixel value                                                 |
+| TileCursorPreciseLeftKey           | LeftShift + Left     | Move the tile cursor left by a specified pixel value                                                 |
+| LimitTileCursorToScreen            | false                | Toggles the ability to move the tile cursor beyond the portion of the map that is visible on screen  |
+| TileCursorPreciseMovementDistance  | 8                    | Specifies how many pixels the cursor should move when using precision tile cursor movement           |
 
 ## Grid Movement Configs
 
-| Name                                  | Default Value | Description                                          |
-| ------------------------------------- | ------------- | ---------------------------------------------------- |
-| GridMovementActive                    | true          | Enable or disable grid movement                      |
-| ToggleGridMovementKey                 | I             | Toggle grid movement                                 |
-| GridMovementOverrideKey               | LeftControl   | Disable Grid Movement while held                     |
-| GridMovementSpeed                     | 100           | Player movement speed (percentage)                   |
-| GridMovementTilesPerStep              | 1             | Tiles moved per step                                 |
-| GridMovementDelayAfterDirectionChange | 250           | Movement delay after changing the player's direction |
+| Name                                   | Default Value  | Description                                           |
+|----------------------------------------|----------------|-------------------------------------------------------|
+| GridMovementActive                     | true           | Enable or disable grid movement                       |
+| ToggleGridMovementKey                  | I              | Toggle grid movement                                  |
+| GridMovementOverrideKey                | LeftControl    | Disable Grid Movement while held                      |
+| GridMovementSpeed                      | 100            | Player movement speed (percentage)                    |
+| GridMovementTilesPerStep               | 1              | Tiles moved per step                                  |
+| GridMovementDelayAfterDirectionChange  | 250            | Movement delay after changing the player's direction  |
 
 ## Object Tracker Configs
 
-| Name                             | Default Value                           | Description                                                                          |
-| -------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
-| OTCycleUpCategory                | LeftControl + PageUp                    | Cycle Up Category                                                                    |
-| OTCycleDownCategory              | LeftControl + PageDown                  | Cycle Down Category                                                                  |
-| OTCycleUpObject                  | PageUp                                  | Cycle Up Object                                                                      |
-| OTCycleDownObject                | PageDown                                | Cycle Down Object                                                                    |
-| OTMoveToSelectedObject           | LeftControl + Home                      | Move to the currently selected object                                                |
-| OTReadSelectedObject             | Home                                    | Read info about the currently selected object                                        |
-| OTReadSelectedObjectTileLocation | End                                     | Read info about the currently selected objects tile location                         |
-| OTCancelAutoWalking              | Escape                                  | Manually stop Auto Walking                                                           |
-| OTSwitchSortingMode              | OemTilde                                | Toggle between proximity and alphabetical sorting                                    |
-| OTSortByProximity                | true                                    | Sets whether proximity sorting mode starts enabled                                   |
-| OTAutoRefreshing                 | true                                    | Sets whether the object tracker auto-refreshes                                       |
-| OTWrapLists                      | false                                   | Sets whether object tracker lists wrap around when the first or last item is reached |
-| OTFavorite1                      | LeftAlt + D1, RightAlt + D1             | Set object tracker favorite slot 1                                                   |
-| OTFavorite2                      | LeftAlt + D2, RightAlt + D2             | Set object tracker favorite slot 2                                                   |
-| OTFavorite3                      | LeftAlt + D3, RightAlt + D3             | Set object tracker favorite slot 3                                                   |
-| OTFavorite4                      | LeftAlt + D4, RightAlt + D4             | Set object tracker favorite slot 4                                                   |
-| OTFavorite5                      | LeftAlt + D5, RightAlt + D5             | Set object tracker favorite slot 5                                                   |
-| OTFavorite6                      | LeftAlt + D16 RightAlt + D6             | Set object tracker favorite slot 6                                                   |
-| OTFavorite7                      | LeftAlt + D7, RightAlt + D7             | Set object tracker favorite slot 7                                                   |
-| OTFavorite8                      | LeftAlt + D8, RightAlt + D8             | Set object tracker favorite slot 8                                                   |
-| OTFavorite9                      | LeftAlt + D9, RightAlt + D9             | Set object tracker favorite slot 9                                                   |
-| OTFavorite10                     | LeftAlt + D0, RightAlt + D0             | Set object tracker favorite slot 10                                                  |
-| OTFavoriteDecreaseStack          | LeftAlt + OemMinus, RightAlt + OemMinus | Browse the previous stack of object tracker favorites                                |
-| OTFavoriteIncreaseStack          | LeftAlt + OemPlus, RightAlt + OemPlus   | Next stack of object tracker favorites                                               |
-| OTFavoriteSaveCoordinatesToggle  | LeftAlt + OemTilde, RightAlt + OemTilde | Toggle the ability to save coordinates to object tracker favorites                   |
-| OTFavoriteSaveDefault            | LeftAlt + Back, RightAlt + Back         | todo                                                                                 |
+| Name                              | Default Value                            | Description                                                                           |
+|-----------------------------------|------------------------------------------|---------------------------------------------------------------------------------------|
+| OTCycleUpCategory                 | LeftControl + PageUp                     | Cycle Up Category                                                                     |
+| OTCycleDownCategory               | LeftControl + PageDown                   | Cycle Down Category                                                                   |
+| OTCycleUpObject                   | PageUp                                   | Cycle Up Object                                                                       |
+| OTCycleDownObject                 | PageDown                                 | Cycle Down Object                                                                     |
+| OTMoveToSelectedObject            | LeftControl + Home                       | Move to the currently selected object                                                 |
+| OTReadSelectedObject              | Home                                     | Read info about the currently selected object                                         |
+| OTReadSelectedObjectTileLocation  | End                                      | Read info about the currently selected objects tile location                          |
+| OTCancelAutoWalking               | Escape                                   | Manually stop Auto Walking                                                            |
+| OTSwitchSortingMode               | OemTilde                                 | Toggle between proximity and alphabetical sorting                                     |
+| OTSortByProximity                 | true                                     | Sets whether proximity sorting mode starts enabled                                    |
+| OTAutoRefreshing                  | true                                     | Sets whether the object tracker auto-refreshes                                        |
+| OTWrapLists                       | false                                    | Sets whether object tracker lists wrap around when the first or last item is reached  |
+| OTFavorite1                       | LeftAlt + D1, RightAlt + D1              | Set object tracker favorite slot 1                                                    |
+| OTFavorite2                       | LeftAlt + D2, RightAlt + D2              | Set object tracker favorite slot 2                                                    |
+| OTFavorite3                       | LeftAlt + D3, RightAlt + D3              | Set object tracker favorite slot 3                                                    |
+| OTFavorite4                       | LeftAlt + D4, RightAlt + D4              | Set object tracker favorite slot 4                                                    |
+| OTFavorite5                       | LeftAlt + D5, RightAlt + D5              | Set object tracker favorite slot 5                                                    |
+| OTFavorite6                       | LeftAlt + D16 RightAlt + D6              | Set object tracker favorite slot 6                                                    |
+| OTFavorite7                       | LeftAlt + D7, RightAlt + D7              | Set object tracker favorite slot 7                                                    |
+| OTFavorite8                       | LeftAlt + D8, RightAlt + D8              | Set object tracker favorite slot 8                                                    |
+| OTFavorite9                       | LeftAlt + D9, RightAlt + D9              | Set object tracker favorite slot 9                                                    |
+| OTFavorite10                      | LeftAlt + D0, RightAlt + D0              | Set object tracker favorite slot 10                                                   |
+| OTFavoriteDecreaseStack           | LeftAlt + OemMinus, RightAlt + OemMinus  | Browse the previous stack of object tracker favorites                                 |
+| OTFavoriteIncreaseStack           | LeftAlt + OemPlus, RightAlt + OemPlus    | Next stack of object tracker favorites                                                |
+| OTFavoriteSaveCoordinatesToggle   | LeftAlt + OemTilde, RightAlt + OemTilde  | Toggle the ability to save coordinates to object tracker favorites                    |
+| OTFavoriteSaveDefault             | LeftAlt + Back, RightAlt + Back          | todo                                                                                  |
 
 ## Radar Configs
 
-| Name             | Default Value | Description                                |
-| ---------------- | ------------- | ------------------------------------------ |
-| Radar            | false         | Toggle Radar                               |
-| RadarStereoSound | true          | Set whether stereo sound is used for radar |
+| Name              | Default Value  | Description                                 |
+|-------------------|----------------|---------------------------------------------|
+| Radar             | false          | Toggle Radar                                |
+| RadarStereoSound  | true           | Set whether stereo sound is used for radar  |
 
 ## Menu Keys Configs
 
@@ -159,80 +159,80 @@ For a full list of key names, refer to the [Key Bindings List](https://stardewva
 
 ### Common Keys
 
-| Name                                 | Default Value | Description                                                                                                                |
-| ------------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| PrimaryInfoKey                       | C             | Used to speak additional info on many menus. More info available here: [Primary Info Key](keybindings.md#primary-info-key) |
-| SnapToFirstInventorySlotKey          | I             | Snaps to the first slot in the player's inventory                                                                          |
-| SnapToFirstSecondaryInventorySlotKey | LeftShift + I | Snaps to the first slot in the secondary inventory, such as a chest                                                        |
-| CraftingMenuCycleThroughRecipesKey   | C             | Cycle through available recipes in the crafting menu                                                                       |
+| Name                                  | Default Value  | Description                                                                                                                 |
+|---------------------------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PrimaryInfoKey                        | C              | Used to speak additional info on many menus. More info available here: [Primary Info Key](keybindings.md#primary-info-key)  |
+| SnapToFirstInventorySlotKey           | I              | Snaps to the first slot in the player's inventory                                                                           |
+| SnapToFirstSecondaryInventorySlotKey  | LeftShift + I  | Snaps to the first slot in the secondary inventory, such as a chest                                                         |
+| CraftingMenuCycleThroughRecipesKey    | C              | Cycle through available recipes in the crafting menu                                                                        |
 
 ### Character Creation Menu (New Game Menu) Keys
 
-| Name                                        | Default Value       | Description                                  |
-| ------------------------------------------- | ------------------- | -------------------------------------------- |
-| CharacterCreationMenuNextKey                | Right               | Go to next element                           |
-| CharacterCreationMenuPreviousKey            | Left                | Go to previous element                       |
-| CharacterCreationMenuDesignToggleKey        | LeftControl + Space | Toggle displaying character creation options |
-| CharacterCreationMenuSliderIncreaseKey      | Up                  | Increase the slider value by 1               |
-| CharacterCreationMenuSliderLargeIncreaseKey | PageUp              | Increase the slider value by 10              |
-| CharacterCreationMenuSliderDecreaseKey      | Down                | Decrease the slider value by 1               |
-| CharacterCreationMenuSliderLargeDecreaseKey | PageDown            | Decrease the slider value by 10              |
+| Name                                         | Default Value        | Description                                   |
+|----------------------------------------------|----------------------|-----------------------------------------------|
+| CharacterCreationMenuNextKey                 | Right                | Go to next element                            |
+| CharacterCreationMenuPreviousKey             | Left                 | Go to previous element                        |
+| CharacterCreationMenuDesignToggleKey         | LeftControl + Space  | Toggle displaying character creation options  |
+| CharacterCreationMenuSliderIncreaseKey       | Up                   | Increase the slider value by 1                |
+| CharacterCreationMenuSliderLargeIncreaseKey  | PageUp               | Increase the slider value by 10               |
+| CharacterCreationMenuSliderDecreaseKey       | Down                 | Decrease the slider value by 1                |
+| CharacterCreationMenuSliderLargeDecreaseKey  | PageDown             | Decrease the slider value by 10               |
 
 ### Junimo Note or Community Center Menu Keys
 
-| Name                              | Default Value | Description                                                  |
-| --------------------------------- | ------------- | ------------------------------------------------------------ |
-| BundleMenuIngredientsKey          | I             | Cycle through the ingredients in the current selected bundle |
-| BundleMenuInventoryItemsKey       | C             | Cycle through the items in the player's inventory            |
-| BundleMenuPurchaseButtonKey       | P             | Move the mouse cursor to purchase button                     |
-| BundleMenuIngredientsInputSlotKey | V             | Cycle through the ingredient input slots                     |
-| BundleMenuBackButtonKey           | Back          | Move the mouse cursor to back button                         |
+| Name                               | Default Value  | Description                                                   |
+|------------------------------------|----------------|---------------------------------------------------------------|
+| BundleMenuIngredientsKey           | I              | Cycle through the ingredients in the current selected bundle  |
+| BundleMenuInventoryItemsKey        | C              | Cycle through the items in the player's inventory             |
+| BundleMenuPurchaseButtonKey        | P              | Move the mouse cursor to purchase button                      |
+| BundleMenuIngredientsInputSlotKey  | V              | Cycle through the ingredient input slots                      |
+| BundleMenuBackButtonKey            | Back           | Move the mouse cursor to back button                          |
 
 ### Chat Menu Configs
 
-| Name                | Default Value | Description                |
-| ------------------- | ------------- | -------------------------- |
-| ChatMenuNextKey     | PageUp        | Read previous chat message |
-| ChatMenuPreviousKey | PageDown      | Read next chat message     |
+| Name                 | Default Value  | Description                 |
+|----------------------|----------------|-----------------------------|
+| ChatMenuNextKey      | PageUp         | Read previous chat message  |
+| ChatMenuPreviousKey  | PageDown       | Read next chat message      |
 
 ## Fishing Mini-Game Configs
 
-| Name                     | Default Value | Description                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MaximumFishingDifficulty | 999           | Every fish have a difficulty value which varies from around 0 to 150. You can use this to limit the maximum difficulty any fish can have.                                                                                                                                                                              |
-| FixFishingMotionType     | 999           | You can fix what motion type every fish has, by default every fish has a fixed motion type like for squid it's sinker, walleye it's smooth, etc. You can use a value between 0 to 4 to fix the motion. 0 indicates mixed motion type, 1 indicates art, 2 indicates smooth, 3 indicates sinker and 4 indicates floater. |
+| Name                      | Default Value  | Description                                                                                                                                                                                                                                                                                                             |
+|---------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MaximumFishingDifficulty  | 999            | Every fish have a difficulty value which varies from around 0 to 150. You can use this to limit the maximum difficulty any fish can have.                                                                                                                                                                               |
+| FixFishingMotionType      | 999            | You can fix what motion type every fish has, by default every fish has a fixed motion type like for squid it's sinker, walleye it's smooth, etc. You can use a value between 0 to 4 to fix the motion. 0 indicates mixed motion type, 1 indicates art, 2 indicates smooth, 3 indicates sinker and 4 indicates floater.  |
 
 ## Narration & Verbosity Configs
 
-| Name                                | Default Value                     | Description                                                                                                                                     |
-| ----------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| RepeatLastTextKey                   | LeftAlt + Space, RightAlt + Space | Repeat the last phrase that was narrated                                                                                                        |
-| HealthNStaminaKey                   | H                                 | Narrate health and stamina.                                                                                                                     |
-| HealthNStaminaInPercentage          | true                              | Whether to speak health and stamina in percentage or the actual value                                                                           |
-| List PositionKey                    | K                                 | Narrate player position.                                                                                                                        |
-| List LocationKey                    | LeftAlt + K                       | Narrate current location name.                                                                                                                  |
-| List MoneyKey                       | R                                 | Narrate the money the player has currently.                                                                                                     |
-| List TimeNSeasonKey                 | Q                                 | Narrate the time of day, day and date and season                                                                                                |
-| Use24HourFormat                     | false                             | Switch time narration between 12-hour and 24-hour                                                                                               |
-| VerboseCoordinates                  | true                              | Whether to speak 'X:' and 'Y:' along with co-ordinates or not                                                                                   |
-| SnapMouse                           | true                              | Toggles the snap mouse feature                                                                                                                  |
-| Warning                             | true                              | Toggles the warnings feature                                                                                                                    |
-| TTS                                 | true                              | Toggles the screen reader/tts.                                                                                                                  |
-| TrackDroppedItems                   | true                              | Toggles detecting the dropped items.                                                                                                            |
-| DisableInventoryVerbosity           | false                             | If enabled, does not speaks 'not usable here' and 'donatable' in inventories                                                                    |
-| DisableBushVerbosity                | false                             | If enabled, does not speak bush type or size; only harvestable.                                                                                 |
-| MacSpeechRate                       | 220                               | Sets speech rate for the Mac TTS.                                                                                                               |
-| DisableDescriptiveDebris            | false                             | Sets whether items such as sticks and stones have more detailed descriptions                                                                    |
-| DisableColorfulSlime                | false                             | Sets whether slime color is read                                                                                                                |
-| ExtraColors                         | false                             | Sets whether the full list of colors is used for color description. [Full color list in this repository](https://github.com/meodai/color-names) |
-| DisableInventoryFluentPluralization | false                             | Sets whether inventory items are pluralized when spoken                                                                                         |
+| Name                                 | Default Value                     | Description                                                                                                                                      |
+|--------------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| RepeatLastTextKey                    | LeftAlt + Space, RightAlt + Space | Repeat the last phrase that was narrated                                                                                                         |
+| HealthNStaminaKey                    | H                                 | Narrate health and stamina.                                                                                                                      |
+| HealthNStaminaInPercentage           | true                              | Whether to speak health and stamina in percentage or the actual value                                                                            |
+| List PositionKey                     | K                                 | Narrate player position.                                                                                                                         |
+| List LocationKey                     | LeftAlt + K                       | Narrate current location name.                                                                                                                   |
+| List MoneyKey                        | R                                 | Narrate the money the player has currently.                                                                                                      |
+| List TimeNSeasonKey                  | Q                                 | Narrate the time of day, day and date and season                                                                                                 |
+| Use24HourFormat                      | false                             | Switch time narration between 12-hour and 24-hour                                                                                                |
+| VerboseCoordinates                   | true                              | Whether to speak 'X:' and 'Y:' along with co-ordinates or not                                                                                    |
+| SnapMouse                            | true                              | Toggles the snap mouse feature                                                                                                                   |
+| Warning                              | true                              | Toggles the warnings feature                                                                                                                     |
+| TTS                                  | true                              | Toggles the screen reader/tts.                                                                                                                   |
+| TrackDroppedItems                    | true                              | Toggles detecting the dropped items.                                                                                                             |
+| DisableInventoryVerbosity            | false                             | If enabled, does not speaks 'not usable here' and 'donatable' in inventories                                                                     |
+| DisableBushVerbosity                 | false                             | If enabled, does not speak bush type or size; only harvestable.                                                                                  |
+| MacSpeechRate                        | 220                               | Sets speech rate for the Mac TTS.                                                                                                                |
+| DisableDescriptiveDebris             | false                             | Sets whether items such as sticks and stones have more detailed descriptions                                                                     |
+| DisableColorfulSlime                 | false                             | Sets whether slime color is read                                                                                                                 |
+| ExtraColors                          | false                             | Sets whether the full list of colors is used for color description. [Full color list in this repository](https://github.com/meodai/color-names)  |
+| DisableInventoryFluentPluralization  | false                             | Sets whether inventory items are pluralized when spoken                                                                                          |
 
 ## miscellaneous Configs
 
-| Name              | Default Value | Description                                                 |
-| ----------------- | ------------- | ----------------------------------------------------------- |
-| YouveGotMailSound | true          | Sets playing a sound when there is new mail in your mailbox |
-| EnableCheats      | false         | Sets whether Stardew Access enables debug mode on startup   |
+| Name               | Default Value  | Description                                                  |
+|--------------------|----------------|--------------------------------------------------------------|
+| YouveGotMailSound  | true           | Sets playing a sound when there is new mail in your mailbox  |
+| EnableCheats       | false          | Sets whether Stardew Access enables debug mode on startup    |
 
 ## Default Config
 

--- a/docs/guides/farming-guides.md
+++ b/docs/guides/farming-guides.md
@@ -107,7 +107,7 @@ The following guides provide instructions on how to purchase and move farm anima
 
 - [Purchasing Farm Animals](#purchasing-farm-animals)
 - [Moving Farm Animals](#moving-farm-animals)
-- [back to top](
+- [back to top](#farming)
 
 ### Purchasing Farm Animals
 

--- a/docs/guides/general-guides.md
+++ b/docs/guides/general-guides.md
@@ -1,8 +1,8 @@
 # General Guides
 
-This page provides general guides for playing Stardew Valley with Stardew Access enabled.  The guides assume that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the [setup page](setup.md).
+This page provides general guides for playing Stardew Valley with Stardew Access enabled.  The guides assume that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the [setup page](../setup.md).
 
-Information about the controls for Stardew Access and Stardew Valley can be found in [Keybindings](keybindings.md).
+Information about the controls for Stardew Access and Stardew Valley can be found in [Keybindings](../keybindings.md).
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@ Information about the controls for Stardew Access and Stardew Valley can be foun
     - primary right click, `left shift + enter` or secondary right click, `]` (right square bracket): emulate a right mouse click
     - WASD: the four navigation keys used to navigate most of the game
     - arrow keys: the four keys used to navigate certain menus
-    - [full list of keybindings](keybindings.md) .
+    - [full list of keybindings](../keybindings.md) .
 - Terms
     - title screen: the first screen you encounter when launching the game.
     - main menu: The menu immediately after the title screen which lets you create and load games.
@@ -94,7 +94,7 @@ The fishing game features many sounds which aren't heard anywhere else in the va
 - [Sine Wave](https://www.youtube.com/watch?v=yyvyt0HyvFk)
 - [Square Wave](https://www.youtube.com/watch?v=HHh-VdsVzmA)
 
-In order to fish, you first need a fishing rod. You can get your first fishing rod by visiting Willy at the beach after he sends you a letter in the mail, usually on day 2 of spring. Once you visit Willy, he will introduce himself and present you with the bamboo pole. You can fish in almost every body of water in the valley, including some elevator levels in [the mines](https://stardewvalleywiki.com/The_Mines). The [object tracker](#object-tracker) will present fishing spots in the fishing category when they are available. These are not necessary to use and you can fish in front of water where you like. These spots make it easy to get to water.
+In order to fish, you first need a fishing rod. You can get your first fishing rod by visiting Willy at the beach after he sends you a letter in the mail, usually on day 2 of spring. Once you visit Willy, he will introduce himself and present you with the bamboo pole. You can fish in almost every body of water in the valley, including some elevator levels in [the mines](https://stardewvalleywiki.com/The_Mines). The [object tracker](../features.md#object-tracker) will present fishing spots in the fishing category when they are available. These are not necessary to use and you can fish in front of water where you like. These spots make it easy to get to water.
 
 Once you have your fishing rod, stand in front of and face the body of water you want to fish in. Hold your tool key to begin casting. You will hear a sine wave rising in pitch. The pitch of this sine wave represents your casting power: the higher the pitch, the further you will cast your line. Release your tool key when you reach the desired power level. You will hear the line splash into the water if your cast was successful, otherwise you must cast again. If you have trouble casting your line, make sure that you're positioned correctly in front of the water and try adjusting your casting power on your next cast. Finding the correct spot can be tricky when fishing in the ocean.
 

--- a/docs/guides/guides-home.md
+++ b/docs/guides/guides-home.md
@@ -1,7 +1,7 @@
 # Guides
 
-These pages provide guides for playing Stardew Valley with Stardew Access enabled. While Stardew Access attempts to provide its players feature parity with the base game, some activities must be performed differently and/or may not be obvious to new players. all pages in this guide assume that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the [setup page](setup.md).
-Information about the controls for Stardew Access and Stardew Valley can be found in [Keybindings](keybindings.md).
+These pages provide guides for playing Stardew Valley with Stardew Access enabled. While Stardew Access attempts to provide its players feature parity with the base game, some activities must be performed differently and/or may not be obvious to new players. all pages in this guide assume that you have already installed both Stardew Valley and Stardew Access as well as all required dependencies. Information on how to install both can be found in the [setup page](../setup.md).
+Information about the controls for Stardew Access and Stardew Valley can be found in [Keybindings](../keybindings.md).
 
 ## Guide Version
 

--- a/docs/guides/stardew-access-guides.md
+++ b/docs/guides/stardew-access-guides.md
@@ -28,11 +28,11 @@ This will open a dialogue which provides you with various options:
 3. Speak detailed tile info
     - Get more information about the selected tile
 
-This feature can be remapped to a controller/gamepad via the `config.json` file. More info available in [keybindings](keybindings.md#tile-viewer-keys) and [configs](config.md#tile-viewer-configs).
+This feature can be remapped to a controller/gamepad via the `config.json` file. More info available in [keybindings](../keybindings.md#tile-viewer-keys) and [configs](../config.md#tile-viewer-configs).
 
 ## Using The Object Tracker
 
-The object tracker is an extremely helpful feature of Stardew Access. It lets you browse all of the items, NPCs, interactable items, and other points of interest on the current map. For a full list of keys and config options, check out the relevant sections in [keybinds](keybindings.md#object-tracker-keys) and [configs](config.md#object-tracker-configs).
+The object tracker is an extremely helpful feature of Stardew Access. It lets you browse all of the items, NPCs, interactable items, and other points of interest on the current map. For a full list of keys and config options, check out the relevant sections in [keybinds](../keybindings.md#object-tracker-keys) and [configs](../config.md#object-tracker-configs).
 
 - [Object Tracker](#object-tracker)
 - [Object Tracker Favorites](#object-tracker-favorites)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -16,151 +16,151 @@ All keybindings may be modified in the config except for escape (esc).
 
 ## Global Keys
 
-| Key                  | Description                                                                                                                                          |
-|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| left ctrl + enter | primary left mouse click                                                                                                             |
-| left shift + enter   | primary right mouse click                                                                                                            |
-| [                     | secondary left mouse click                                                                                                           |
-| ]                    | secondary right mouse click                                                                                                          |
-| h                    | narrate health and stamina                                                                                                                          |
-| left alt + k         | narrate current map                                                                                                                       |
-| k                    | narrate current coordinates.                                                                                                                             |
-| q                    | narrate time, date, and season                                                                                                    |
-| r                    | Narrate current money -- additional currency info when used in the inventory menu  |
-| left alt + j         | narrate the tile the player is standing on                                                                                     |
-| j                    | narrate the tile the player is facing                                                                                      |
-| c                    | primary info key -- see [Primary Info Key](#primary-info-key) for details                                                              |
-| esc| closing menus -- stop interacting with text boxes                                                                                                    |
+| Key                   | Description                                                                                                                                           |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| left ctrl + enter     | primary left mouse click                                                                                                                              |
+| left shift + enter    | primary right mouse click                                                                                                                             |
+| [                     | secondary left mouse click                                                                                                                            |
+| ]                     | secondary right mouse click                                                                                                                           |
+| h                     | narrate health and stamina                                                                                                                            |
+| left alt + k          | narrate current map                                                                                                                                   |
+| k                     | narrate current coordinates.                                                                                                                          |
+| q                     | narrate time, date, and season                                                                                                                        |
+| r                     | Narrate current money -- additional currency info when used in the inventory menu                                                                     |
+| left alt + j          | narrate the tile the player is standing on                                                                                                            |
+| j                     | narrate the tile the player is facing                                                                                                                 |
+| c                     | primary info key -- see [Primary Info Key](#primary-info-key) for details                                                                             |
+| esc                   | closing menus -- stop interacting with text boxes                                                                                                     |
 
 ## Tile Viewer Keys
 
-| Key                      | Description                                                                             |
-|--------------------------|-----------------------------------------------------------------------------------------|
-| l                        | toggle relative cursor lock |
-| left ctrl + enter     | move the player to the focused tile                                                                   |
-| left shift + enter       | open the Tile Info Menu for the focused tile                                            |       
-| arrow up                 | move the tile cursor one tile up                                                             |
-| arrow right              | move the tile cursor one tile right                                                          |
-| arrow down               | move the tile cursor one tile down                                                           |
-| arrow left               | move the tile cursor one tile left                                                           |
-| left shift + arrow up    | move the tile cursor up pixel by pixel                                    |
-| left shift + arrow right | move the tile cursor right pixel by pixel                                 |
-| left shift + arrow down  | move the tile cursor down pixel by pixel                                  |
-| left shift + arrow left  | move the tile cursor left pixel by pixel                                  |
+| Key                       | Description                                                                              |
+|---------------------------|------------------------------------------------------------------------------------------|
+| l                         | toggle relative cursor lock                                                              |
+| left ctrl + enter         | move the player to the focused tile                                                      |
+| left shift + enter        | open the Tile Info Menu for the focused tile                                             |       
+| arrow up                  | move the tile cursor one tile up                                                         |
+| arrow right               | move the tile cursor one tile right                                                      |
+| arrow down                | move the tile cursor one tile down                                                       |
+| arrow left                | move the tile cursor one tile left                                                       |
+| left shift + arrow up     | move the tile cursor up pixel by pixel                                                   |
+| left shift + arrow right  | move the tile cursor right pixel by pixel                                                |
+| left shift + arrow down   | move the tile cursor down pixel by pixel                                                 |
+| left shift + arrow left   | move the tile cursor left pixel by pixel                                                 |
 
 ## Grid Movement Keys
 
-| Key          | Description                      |
-|--------------|----------------------------------|
-| i            | Toggle grid movement             |
-| left ctrl | disable grid movement while held |
+| Key           | Description                       |
+|---------------|-----------------------------------|
+| i             | Toggle grid movement              |
+| left ctrl     | disable grid movement while held  |
 
 ## Object Tracker Keys
 
-| Key                    | Description                                                   |
-|------------------------|---------------------------------------------------------------|
-| left ctrl + pageUp | previous category                                             |
-| left ctrl + pageDown | next Category                                           |
-| pageUp                 | previous object                                               |
-| pageDown               | next Object                                             |
-| left ctrl + home     | move to the selected object.                        |
-| home                   | narrate info about the selected object                |
-| end                    | narrate info about the selected objects tile location |
-| esc| stop walking to a selected tile or object                                   |
-| ~                  | toggle between alphabetical and proximity object sorting                      |
-| alt + 1 | object tracker favorite slot 1 info |
-| alt + 2 | object tracker favorite slot 2 info |
-| alt + 3 | object tracker favorite slot 3 info |
-| alt + 4 | object tracker favorite slot 4 info |
-| alt + 5 | object tracker favorite slot 5 info |
-| alt + 6 | object tracker favorite slot 6 info |
-| alt + 7 | object tracker favorite slot 7 info |
-| alt + 8 | object tracker favorite slot 8 info |
-| alt + 9 | object tracker favorite slot 9 info |
-| alt + 0 | object tracker favorite slot 10 info |
-| alt + double-tap 1 | Set object tracker favorite slot 1 -- travel to slot 1 if already set |
-| alt + double-tap 2 | Set object tracker favorite slot 2 -- travel to slot 2 if already set |
-| alt + double-tap 3 | Set object tracker favorite slot 3 -- travel to slot 3 if already set |
-| alt + double-tap 4 | Set object tracker favorite slot 4 -- travel to slot 4 if already set |
-| alt + double-tap 5 | Set object tracker favorite slot 5 -- travel to slot 5 if already set |
-| alt + double-tap 6 | Set object tracker favorite slot 6 -- travel to slot 6 if already set |
-| alt + double-tap 7 | Set object tracker favorite slot 7 -- travel to slot 7 if already set |
-| alt + double-tap 8 | Set object tracker favorite slot 8 -- travel to slot 8 if already set |
-| alt + double-tap 9 | Set object tracker favorite slot 9 -- travel to slot 9 if already set |
-| alt + double-tap 0 | Set object tracker favorite slot 10 -- travel to slot 10 if already set |
-| alt + triple-tap 1 | clear object tracker favorite slot 1 |
-| alt + triple-tap 2 | clear object tracker favorite slot 2 |
-| alt + triple-tap 3 | clear object tracker favorite slot 3 |
-| alt + triple-tap 4 | clear object tracker favorite slot 4 |
-| alt + triple-tap 5 | clear object tracker favorite slot 5 |
-| alt + triple-tap 6 | clear object tracker favorite slot 6 |
-| alt + triple-tap 7 | clear object tracker favorite slot 7 |
-| alt + triple-tap 8 | clear object tracker favorite slot 8 |
-| alt + triple-tap 9 | clear object tracker favorite slot 9 |
-| alt + triple-tap 0 | clear object tracker favorite slot 10 |
-| alt + - | previous stack of object tracker favorites |
-| alt + = | next stack of object tracker favorites |
+| Key                     | Description                                                             |
+|-------------------------|-------------------------------------------------------------------------|
+| left ctrl + pageUp      | previous category                                                       |
+| left ctrl + pageDown    | next Category                                                           |
+| pageUp                  | previous object                                                         |
+| pageDown                | next Object                                                             |
+| left ctrl + home        | move to the selected object.                                            |
+| home                    | narrate info about the selected object                                  |
+| end                     | narrate info about the selected objects tile location                   |
+| esc                     | stop walking to a selected tile or object                               |
+| ~                       | toggle between alphabetical and proximity object sorting                |
+| alt + 1                 | object tracker favorite slot 1 info                                     |
+| alt + 2                 | object tracker favorite slot 2 info                                     |
+| alt + 3                 | object tracker favorite slot 3 info                                     |
+| alt + 4                 | object tracker favorite slot 4 info                                     |
+| alt + 5                 | object tracker favorite slot 5 info                                     |
+| alt + 6                 | object tracker favorite slot 6 info                                     |
+| alt + 7                 | object tracker favorite slot 7 info                                     |
+| alt + 8                 | object tracker favorite slot 8 info                                     |
+| alt + 9                 | object tracker favorite slot 9 info                                     |
+| alt + 0                 | object tracker favorite slot 10 info                                    |
+| alt + double-tap 1      | Set object tracker favorite slot 1 -- travel to slot 1 if already set   |
+| alt + double-tap 2      | Set object tracker favorite slot 2 -- travel to slot 2 if already set   |
+| alt + double-tap 3      | Set object tracker favorite slot 3 -- travel to slot 3 if already set   |
+| alt + double-tap 4      | Set object tracker favorite slot 4 -- travel to slot 4 if already set   |
+| alt + double-tap 5      | Set object tracker favorite slot 5 -- travel to slot 5 if already set   |
+| alt + double-tap 6      | Set object tracker favorite slot 6 -- travel to slot 6 if already set   |
+| alt + double-tap 7      | Set object tracker favorite slot 7 -- travel to slot 7 if already set   |
+| alt + double-tap 8      | Set object tracker favorite slot 8 -- travel to slot 8 if already set   |
+| alt + double-tap 9      | Set object tracker favorite slot 9 -- travel to slot 9 if already set   |
+| alt + double-tap 0      | Set object tracker favorite slot 10 -- travel to slot 10 if already set |
+| alt + triple-tap 1      | clear object tracker favorite slot 1                                    |
+| alt + triple-tap 2      | clear object tracker favorite slot 2                                    |
+| alt + triple-tap 3      | clear object tracker favorite slot 3                                    |
+| alt + triple-tap 4      | clear object tracker favorite slot 4                                    |
+| alt + triple-tap 5      | clear object tracker favorite slot 5                                    |
+| alt + triple-tap 6      | clear object tracker favorite slot 6                                    |
+| alt + triple-tap 7      | clear object tracker favorite slot 7                                    |
+| alt + triple-tap 8      | clear object tracker favorite slot 8                                    |
+| alt + triple-tap 9      | clear object tracker favorite slot 9                                    |
+| alt + triple-tap 0      | clear object tracker favorite slot 10                                   |
+| alt + -                 | previous stack of object tracker favorites                              |
+| alt + =                 | next stack of object tracker favorites                                  |
 
 ## Chat Menu keys
 
 Active when the chat window is opened with `t`
 
-| Key                       | Description                                                                                                            |
-|---------------------------|------------------------------------------------------------------------------------------------------------------------|
-| pageUp                   | Read previous chat message                                                                                             |
-| pageDown                 | Read next chat message                                                                                                 |
-| left alt + (1-9)  | read previous chat message in order of age      |
-| right alt + (1-9) | read previous notifications in order of age |
+| Key                        | Description                                                                                                             |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| pageUp                     | Read previous chat message                                                                                              |
+| pageDown                   | Read next chat message                                                                                                  |
+| left alt + (1-9)           | read previous chat message in order of age                                                                              |
+| right alt + (1-9)          | read previous notifications in order of age                                                                             |
 
 ## New Game or Character Customization Menu Keys
 
 These keys are used in the context of the character creation/new game menu.
 
-| Key                  | Description                                |
-|----------------------|--------------------------------------------|
-| right arrow          | move to next element                        |
-| left arrow           | move to previous element                    |
-| left ctrl + space | Toggle displaying character design options |
-| up arrow             | increase control value by 1             |
-| pageUp              | increase control value by 10            |
-| down arrow           | decrease control value by 1             |
-| pageDown            | decrease control value by 10            |
-| esc | stop interacting with a text box |
+| Key                   | Description                                 |
+|-----------------------|---------------------------------------------|
+| right arrow           | move to next element                        |
+| left arrow            | move to previous element                    |
+| left ctrl + space     | Toggle displaying character design options  |
+| up arrow              | increase control value by 1                 |
+| pageUp                | increase control value by 10                |
+| down arrow            | decrease control value by 1                 |
+| pageDown              | decrease control value by 10                |
+| esc                   | stop interacting with a text box            |
 
 ## Menus With Inventory Keys
 
 This includes menus such as shop menus and chest menus.
 
-| Key            | Description                                                          |
-|----------------|----------------------------------------------------------------------|
-| i              | select first item in the crafting/chest/shop menu |
-| left shift + i | select first item in the player's inventory                      |
+| Key             | Description                                                           |
+|-----------------|-----------------------------------------------------------------------|
+| i               | select first item in the crafting/chest/shop menu                     |
+| left shift + i  | select first item in the player's inventory                           |
 
 ## Junimo Note or Community Center Menu Keys
 
-| Key                 | Description                                                  |
-|---------------------|--------------------------------------------------------------|
-| i  | next item in a bundle |
-| left shift + i | previous item in a bundle |
-| c  | next item in player inventory            |
-| left shift + c | previous item in player inventory |
-| v | next ingredient slot in bundle                     |
-| left shift + v | previous item slot in bundle |
-| p                   | Move the mouse cursor to the purchase button                     |
-| backspace           | Move the mouse cursor to the back button                         |
+| Key                  | Description                                                   |
+|----------------------|---------------------------------------------------------------|
+| i                    | next item in a bundle                                         |
+| left shift + i       | previous item in a bundle                                     |
+| c                    | next item in player inventory                                 |
+| left shift + c       | previous item in player inventory                             |
+| v                    | next ingredient slot in bundle                                |
+| left shift + v       | previous item slot in bundle                                  |
+| p                    | Move the mouse cursor to the purchase button                  |
+| backspace            | Move the mouse cursor to the back button                      |
 
 ## Primary Info Key
 
 `c` by default is used in several menus. They are as follows:
 
-| Menu             | Usage                                      |
-|------------------|--------------------------------------------|
-| Crafting Menu | move to the next available recipe |
-| Construction Menu   | Speak the info about the current blueprint |
-| Animal Info Menu | Speak the animal's detail                  |
-| Museum Menu      | Donate focused item              |
-| Fish Pond Menu   | Speak info about the selected pond                   |
-| Quest Menu       | Speak current quest info                   |
+| Menu              | Usage                                       |
+|-------------------|---------------------------------------------|
+| Crafting Menu     | move to the next available recipe           |
+| Construction Menu | Speak the info about the current blueprint  |
+| Animal Info Menu  | Speak the animal's detail                   |
+| Museum Menu       | Donate focused item                         |
+| Fish Pond Menu    | Speak info about the selected pond          |
+| Quest Menu        | Speak current quest info                    |
 
 ## Other Pages
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,7 +68,7 @@ If you prefer to install SMAPI, Stardew Access, and its dependencies manually, y
 2. Download the [latest version of SMAPI](https://smapi.io/).
 3. Extract the .zip file somewhere. (Your downloads folder is fine).
 4. Open the new folder once it has finished unzipping. You may need to open two folders to get to the contents.
-4. Double-click `install on Windows.bat`, and follow the on-screen instructions.
+5. Double-click `install on Windows.bat`, and follow the on-screen instructions.
 
 ##### Xbox App Setup
 
@@ -117,7 +117,7 @@ This process is done when installing SMAPI on an Xbox App copy.
     - As an alternative, focus on Stardew Valley in the grid, use `NVDA + numpad divide` to route the mouse cursor to the element, and then use `numpad multiply` to right-click and open the context menu
 7. In the context menu, find and select "properties"
 8. Ensure you are focused on the "General" tab in the new window and press `right arrow` to enter the general section
-    - If you are not using focus mode, you may either press `e` to move to the text box described in step 9 or disable automatic move of the system focus due to browse mode commands" with `NVDA + 8` and use the down arrow immediately to find the text box described in step 9
+    - If you are not using focus mode, you may either press `e` to move to the text box described in step 9 or disable automatic move of the system focus due to browse mode commands with `NVDA + 8` and use the down arrow immediately to find the text box described in step 9
 9. Arrow down until you come across a text box located shortly after a button labeled "default" and paste the following text:
     - `"C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe" %command%`
 10. Once you have entered the text, exit Big Picture mode with `alt + f4`. The text you just entered is saved automatically

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -4,7 +4,7 @@ using StardewModdingAPI.Events;
 using System.Text.RegularExpressions;
 using Translation;
 using StardewValley;
-using stardew_access.Utils;
+using Utils;
 using StardewModdingAPI;
 
 internal class GameStateNarrator : FeatureBase
@@ -130,7 +130,7 @@ internal class GameStateNarrator : FeatureBase
             if (hudMessageQueryKey != searchQuery)
             {
                 hudMessageQueryKey = searchQuery;
-                MainClass.ScreenReader.Say(toSpeak, true);
+                MainClass.ScreenReader.Say(toSpeak, false);
                 HudMessagesBuffer.Add(toSpeak);
             }
         }

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -130,7 +130,7 @@ internal class GameStateNarrator : FeatureBase
             if (hudMessageQueryKey != searchQuery)
             {
                 hudMessageQueryKey = searchQuery;
-                MainClass.ScreenReader.Say(toSpeak, false);
+                MainClass.ScreenReader.Say(toSpeak, true);
                 HudMessagesBuffer.Add(toSpeak);
             }
         }

--- a/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
@@ -12,8 +12,8 @@ internal class SpecialOrdersBoardPatch : IPatch
     public void Apply(Harmony harmony)
     {
         harmony.Patch(
-                original: AccessTools.Method(typeof(SpecialOrdersBoard), nameof(SpecialOrdersBoard.draw), [typeof(SpriteBatch)]),
-                postfix: new HarmonyMethod(typeof(SpecialOrdersBoardPatch), nameof(SpecialOrdersBoardPatch.DrawPatch))
+            original: AccessTools.Method(typeof(SpecialOrdersBoard), nameof(SpecialOrdersBoard.draw), [typeof(SpriteBatch)]),
+            postfix: new HarmonyMethod(typeof(SpecialOrdersBoardPatch), nameof(DrawPatch))
         );
     }
 
@@ -110,6 +110,6 @@ internal class SpecialOrdersBoardPatch : IPatch
         if (!flag2 && Game1.player.team.acceptedSpecialOrderTypes.Contains(__instance.GetOrderType()))
             flag1 = true;
 
-        return flag1;
+        return !flag1;
     }
 }

--- a/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
@@ -43,9 +43,19 @@ internal class SpecialOrdersBoardPatch : IPatch
                 return;
             }
 
-            SpecialOrder inProgress = IsInProgress(__instance.leftOrder, __instance) ? __instance.leftOrder : __instance.rightOrder;
+            SpecialOrder? inProgress = IsInProgress(__instance.leftOrder, __instance)
+                ? __instance.leftOrder
+                : IsInProgress(__instance.rightOrder, __instance)
+                    ? __instance.rightOrder
+                    : null;
 
-            if (__instance.boardType == "" && Game1.player.team.completedSpecialOrders.Contains(inProgress.questKey.Value))
+            if (inProgress is null)
+            {
+                MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-no_active_quest", true);
+                return;
+            }
+
+            if (Game1.player.team.completedSpecialOrders.Contains(inProgress.questKey.Value))
             {
                 MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_completed", true, new
                 {
@@ -54,14 +64,10 @@ internal class SpecialOrdersBoardPatch : IPatch
                 return;
             }
 
-            if (Game1.player.team.acceptedSpecialOrderTypes.Contains(__instance.GetOrderType()))
+            MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_in_progress", true, new
             {
-                MainClass.ScreenReader.TranslateAndSayWithMenuChecker("menu-special_orders_board-quest_in_progress", true, new
-                {
-                    quest_details = GetQuestDetails(inProgress)
-                });
-                return;
-            }
+                quest_details = GetQuestDetails(inProgress)
+            });
         }
         catch (Exception e)
         {
@@ -84,6 +90,7 @@ internal class SpecialOrdersBoardPatch : IPatch
 
     private static bool IsInProgress(SpecialOrder order, SpecialOrdersBoard __instance)
     {
+        // Ref: SpecialOrdersBoard::draw()
         bool flag1 = false;
         bool flag2 = false;
         foreach (SpecialOrder specialOrder in Game1.player.team.specialOrders)

--- a/stardew-access/Utils/DynamicTiles.cs
+++ b/stardew-access/Utils/DynamicTiles.cs
@@ -1029,6 +1029,13 @@ public class DynamicTiles
             return ("tile-town-krobus_hiding_bush", CATEGORY.Quest);
         }
 
+        if (x is 60 && y is 93 && SpecialOrder.IsSpecialOrdersBoardUnlocked() && !Game1.isFestival())
+        {
+            int tickets = (int)Game1.player.stats.Get("specialOrderPrizeTickets");
+            string name = Translator.Instance.Translate("tile-town-prize_ticket_box", new { tickets = tickets });
+            return (name, tickets > 0 ? CATEGORY.Pending : CATEGORY.Buildings);
+        }
+
         return (null, null);
     }
 

--- a/stardew-access/Utils/DynamicTiles.cs
+++ b/stardew-access/Utils/DynamicTiles.cs
@@ -1006,7 +1006,7 @@ public class DynamicTiles
     {
         if (SpecialOrder.IsSpecialOrdersBoardUnlocked() && x == 62 && y == 93)
         {
-            return ("tile_name-special_quest_board", CATEGORY.Interactables);
+            return ("tile-town-special_orders_board", CATEGORY.Interactables);
         }
 
         if (Utility.doesMasterPlayerHaveMailReceivedButNotMailForTomorrow("ccMovieTheater") && x == 98 && y == 51)

--- a/stardew-access/Utils/TileInfo.cs
+++ b/stardew-access/Utils/TileInfo.cs
@@ -309,7 +309,7 @@ public class TileInfo
                     characterName = Translator.Instance.Translate("npc_name-pet", new
                     {
                         can_be_pet = wasPetToday ? 0 : 1,
-                        name = TokenParser.ParseText(pet.GetPetData().DisplayName)
+                        name = pet.getName()
                     });
                     characterCategory = wasPetToday ? CATEGORY.NPCs : CATEGORY.Pending;
                     break;

--- a/stardew-access/i18n/en.ftl
+++ b/stardew-access/i18n/en.ftl
@@ -214,7 +214,6 @@ tile_name-feeding_bench = {$is_empty ->
     [1] Empty
     *[0] {EMPTYSTRING()}
   } Feeding Bench
-tile_name-special_quest_board = Special Quest Board
 tile-museum_piece_showcase-suffix = {$content} Showcase
 tile_name-fridge = Fridge
 tile_name-mail_box = Mail Box
@@ -247,6 +246,7 @@ tile-volcano_dungeon-gate = Gate
 tile-forest-giant_tree_sump = Giant Tree Stump
 tile-town-bookseller = Bookseller
 tile-town-krobus_hiding_bush = Strange Bush
+tile-town-special_orders_board = Special Orders Board
 tile-town-prize_ticket_box = Prize Ticket Box{$tickets ->
     [0] {EMPTYSTRING()}
     [1] , with 1 prize ticket

--- a/stardew-access/i18n/en.ftl
+++ b/stardew-access/i18n/en.ftl
@@ -247,6 +247,11 @@ tile-volcano_dungeon-gate = Gate
 tile-forest-giant_tree_sump = Giant Tree Stump
 tile-town-bookseller = Bookseller
 tile-town-krobus_hiding_bush = Strange Bush
+tile-town-prize_ticket_box = Prize Ticket Box{$tickets ->
+    [0] {EMPTYSTRING()}
+    [1] , with 1 prize ticket
+    *[any] , with {$tickets} prize tickets 
+  }
 
 ## Entrances
 

--- a/stardew-access/i18n/menu.en.ftl
+++ b/stardew-access/i18n/menu.en.ftl
@@ -664,6 +664,7 @@ menu-special_orders_board-accept_button = {$is_left_quest ->
   Left click to accept this quest.
 menu-special_orders_board-quest_in_progress = In progress: {$quest_details}
 menu-special_orders_board-quest_completed = Quest {$name} completed! Open journal to collect your reward.
+menu-special_orders_board-no_active_quest = No active quest
 
 ## Title Menus
 

--- a/stardew-access/manifest.json
+++ b/stardew-access/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Stardew Access",
   "Author": "Mohammad Shoaib Khan and Katalina Tudela",
-  "Version": "1.6.0",
+  "Version": "1.6.1",
   "Description": "A mod that improves the accessibility of the game for visually impaired players.",
   "UniqueID": "shoaib.stardewaccess",
   "EntryDll": "stardew-access.dll",


### PR DESCRIPTION
## Changelog

### Bug Fixes

- Fixed pet names not speaking.
- Fixed special orders board speaking incorrect quest status (in progress and completed).

### Tile Tracker Changes

- Tracked prize ticket box.
- Renamed special quest board to special orders board.

### Translation Changes

- Removed(en.ftl): `tile_name-special_quest_board`
- New(en.ftl): `tile-town-special_orders_board` = `Special Orders Board`
- New(en.ftl): `tile-town-prize_ticket_box` = [English Value](https://github.com/khanshoaib3/stardew-access-local/blob/71a69961e52a999e85e647557843f160710a4956/stardew-access/i18n/en.ftl#L250-L254)
- New(menu.en.ftl): `menu-special_orders_board-no_active_quest` = `No active quest`

### Guides And Docs

- Fixed and updated links (partly done by @BrailleBennett) and table formats (no change visually or in rendering).
