### PR TITLE
fix: Guides are now included in the docs

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -16,6 +16,7 @@
 ### Guides And Docs
 
 - Removed contributors section and added translation section in the readme.
+- Guides are now published in the docs folder
 
 ### Misc
 

--- a/stardew-access/stardew-access.csproj
+++ b/stardew-access/stardew-access.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="compiled-docs\*">
-      <Link>docs\%(Filename)%(Extension)</Link>
+    <None Update="compiled-docs\**">
+      <Link>docs\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="KdTreeLib.dll">


### PR DESCRIPTION
Fixes #484

Guides were not included in the docs output after building the mod.

Now all files and subdirectories in the compiled-docs folder will be published with the build.

[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog


### Guides And Docs
- Guides are now published in the docs folder

