### PR TITLE
docs: Added contributing guide for developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to Stardew Access
+
+Thank you for your interest in contributing! We welcome improvements, bug fixes, new features, and documentation updates.
+
+---
+
+## How to Contribute
+
+1. **Fork the repository** and clone your fork locally.
+2. **Create a new branch** for your changes.
+3. **Make your changes** and commit with clear messages.
+4. **Push your branch** to your fork.
+5. **Open a Pull Request** describing your changes.
+
+---
+
+## Project Setup
+
+To set up Stardew Access locally:
+
+1. **Clone your fork:**
+	```sh
+	git clone https://github.com/your-username/stardew-access.git
+	cd stardew-access
+	```
+
+2. **Install dependencies:**
+	 - Ensure you have [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) installed.
+	 - You will need [Ruby](https://www.ruby-lang.org/en/downloads/) for compiling docs (see `docs/compiler_script.rb`).
+	 - Install the required Ruby gem for documentation:
+		 ```sh
+		 gem install kramdown
+		 ```
+
+3. **Build the project:**
+	```sh
+	dotnet build stardew-access.sln
+	```
+
+4. **Run or test the mod:**
+	- Place the built files in your Stardew Valley `Mods` folder.
+	- Follow instructions in [docs/setup.md](docs/setup.md) for more details.
+
+5. **Compile documentation (optional):**
+	```sh
+	cd docs
+	ruby compiler_script.rb
+	```
+
+---
+
+## Code Style
+
+- Follow the existing code conventions.
+- Write clear, maintainable code.
+- Add comments where necessary.
+- Update or add documentation as needed.
+
+---
+
+## Reporting Issues & Requesting Features
+
+- Use GitHub Issues for bugs, feature requests, or questions.
+- Provide as much detail as possible.
+
+---
+
+## Pull Requests
+
+- Ensure your branch is up to date with the main branch.
+- Fill out the PR template.
+- Be responsive to feedback and requested changes.
+
+---
+
+## Code of Conduct
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+## License
+
+By contributing, you agree your contributions are licensed under the repository’s license.
+
+---
+
+## Contact
+
+For questions or support, reach out via GitHub Issues or our [Discord server](https://discord.gg/yQjjsDqWQX).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ To set up Stardew Access locally:
 		 ```sh
 		 gem install kramdown
 		 ```
+	 - You need [Project Fluent](https://www.nexusmods.com/stardewvalley/mods/12638) (required for translations/localization).
+			 Download and extract it so your folder structure looks like:
+			 ```
+			 <GamePath>/Mods/ProjectFluent/ProjectFluent.dll
+			 ```
+			 Where `<GamePath>` is the location of your Stardew Valley installation.
 
 3. **Build the project:**
 	```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Check out the [official guide](guides/guides-home.md) for tutorials on creating 
     - post any bug or feature request here.
 - [Source Code](https://github.com/stardew-access/stardew-access)
     - contributions are always welcome!
+- [Contributing guide for developers](https://github.com/stardew-access/stardew-access/CONTRIBUTING.md)
 - [Developer's wiki](https://github.com/stardew-access/stardew-access/wiki)
 - [Stardew Access on Nexus Mods](https://www.nexusmods.com/stardewvalley/mods/16205)
 - [Latest Release](https://github.com/stardew-access/stardew-access/releases/latest)

--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -17,6 +17,7 @@
 
 - Removed contributors section and added translation section in the readme.
 - Guides are now published in the docs folder
+- Added contributing guide for developers
 
 ### Misc
 


### PR DESCRIPTION
Fixes #486

A contributing guide has now been added with sections to help devs understand how to set up the project and how best to contribute. Places for adding future things like style guidelines and code quality requirements have been included to help make this more expandable in the future.

[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog


### Guides And Docs
- Added contributing guide for developers
