### PR TITLE
fix: Updated HUD message query regex to preserve digits

### DIFF
--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -125,7 +125,7 @@ internal class GameStateNarrator : FeatureBase
             int lastIndex = Game1.hudMessages.Count - 1;
             HUDMessage lastMessage = Game1.hudMessages[lastIndex];
             string toSpeak = lastMessage.message;
-            var searchQuery = (Regex.Replace(toSpeak, @"[\d+]", string.Empty)).Trim();
+            var searchQuery = toSpeak.Trim();
 
             if (hudMessageQueryKey != searchQuery)
             {


### PR DESCRIPTION
Fixes #489
Removed the regex that stripped digits from HUD messages before comparison. This ensures that the search query retains all characters, including numbers, which may be important for accurate message handling.

[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog

### New Features


### Feature Updates


### Bug Fixes


### Tile Tracker Changes


### Guides And Docs


### Misc


### Translation Changes


### Development Chores


