### PR TITLE
feat: Add timeout for suppressing duplicate HUD messages

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -6,6 +6,7 @@
 
 ### Feature Updates
 
+- You can now set a timeout for ignoring duplicated hud messages. Previously duplicate messages were always ignored but now you can configure the timeout between allowing them. The default is 5000 (5 seconds) and you can set it to 0 to disable it. Messages where the only difference is a number are considered duplicates.
 
 ### Bug Fixes
 

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -16,6 +16,7 @@ internal class GameStateNarrator : FeatureBase
     private static GameLocation? previousLocation;
 
     private static string hudMessageQueryKey = "";
+    private static DateTime lastHudMessageTime = DateTime.MinValue;
     private static bool isNarratingHudMessage = false;
 
     private static GameStateNarrator? instance;
@@ -126,10 +127,14 @@ internal class GameStateNarrator : FeatureBase
             HUDMessage lastMessage = Game1.hudMessages[lastIndex];
             string toSpeak = lastMessage.message;
             var searchQuery = (Regex.Replace(toSpeak, @"[\d+]", string.Empty)).Trim();
+            var now = DateTime.Now;            
+            bool isDuplicate = hudMessageQueryKey == searchQuery;
+            bool withinTimeout = (now - lastHudMessageTime).TotalSeconds < MainClass.Config.HudDuplicateMessageTimeoutSeconds;
 
-            if (hudMessageQueryKey != searchQuery)
+            if (!isDuplicate || !withinTimeout)
             {
                 hudMessageQueryKey = searchQuery;
+                lastHudMessageTime = now;
                 MainClass.ScreenReader.Say(toSpeak, true);
                 HudMessagesBuffer.Add(toSpeak);
             }

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -129,7 +129,7 @@ internal class GameStateNarrator : FeatureBase
             var searchQuery = (Regex.Replace(toSpeak, @"[\d+]", string.Empty)).Trim();
             var now = DateTime.Now;            
             bool isDuplicate = hudMessageQueryKey == searchQuery;
-            bool withinTimeout = (now - lastHudMessageTime).TotalSeconds < MainClass.Config.HudDuplicateMessageTimeoutSeconds;
+            bool withinTimeout = (now - lastHudMessageTime) < TimeSpan.FromMilliseconds(MainClass.Config.HudDuplicateMessageTimeout);
 
             if (!isDuplicate || !withinTimeout)
             {

--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -557,6 +557,11 @@ internal class ModConfig
         set { _EggHuntTimerMultiplier = Math.Clamp(value, 1f, 3f); }
     }
 
+    /// <summary>
+    /// The time window (in seconds) to suppress duplicate HUD messages. If a duplicate message occurs within this interval, it will be ignored. Default is 5 seconds. <see langword="set"/> to 0 to disable this feature.
+    /// </summary>
+    public int HudDuplicateMessageTimeoutSeconds { get; set; } = 5;
+
     // TODO Add the exclusion and focus list too
     // public String ExclusionList { get; set; } = "test";
 }

--- a/stardew-access/ModConfig.cs
+++ b/stardew-access/ModConfig.cs
@@ -558,9 +558,9 @@ internal class ModConfig
     }
 
     /// <summary>
-    /// The time window (in seconds) to suppress duplicate HUD messages. If a duplicate message occurs within this interval, it will be ignored. Default is 5 seconds. <see langword="set"/> to 0 to disable this feature.
+    /// The time window (in miliseconds) to suppress duplicate HUD messages. If a duplicate message occurs within this interval, it will be ignored. Default is 5 miliseconds. <see langword="set"/> to 0 to disable this feature.
     /// </summary>
-    public int HudDuplicateMessageTimeoutSeconds { get; set; } = 5;
+    public int HudDuplicateMessageTimeout { get; set; } = 5000;
 
     // TODO Add the exclusion and focus list too
     // public String ExclusionList { get; set; } = "test";


### PR DESCRIPTION
Fixes #489 
Introduces a configurable HudDuplicateMessageTimeoutSeconds option to ModConfig, allowing suppression of duplicate HUD messages within a specified time window. Updates GameStateNarrator to use this timeout, preventing repeated narration of the same message in quick succession.

[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog

### Feature Updates

- You can now set a timeout for ignoring duplicated hud messages. Previously duplicate messages were always ignored but now you can configure the timeout between allowing them. The default is 5000 (5 seconds) and you can set it to 0 to disable it. Messages where the only difference is a number are considered duplicates.
