### PR TITLE
Expose commands to API

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -22,6 +22,7 @@
 
 ### Misc
 
+- Exposed keybindings some keybindings to the api, including the mouse sim keybinds,  primary info keybind and some others - by @paulGeoghegan
 
 ### Translation Changes
 

--- a/stardew-access/API.cs
+++ b/stardew-access/API.cs
@@ -45,6 +45,7 @@ public class API : IStardewAccessApi
     public KeybindList TileCursorRightKey => MainClass.Config.TileCursorRightKey;
     public KeybindList TileCursorDownKey => MainClass.Config.TileCursorDownKey;
     public KeybindList TileCursorLeftKey => MainClass.Config.TileCursorLeftKey;
+    public KeybindList PrimaryInfoKey => MainClass.Config.PrimaryInfoKey;
     #endregion
 
     #region Screen reader related
@@ -79,7 +80,6 @@ public class API : IStardewAccessApi
         set => MainClass.ScreenReader.MenuSuffixNoQueryText = value;
     }
 
-    public KeybindList PrimaryInfoKey => MainClass.Config.PrimaryInfoKey;
 
     public bool Say(string text, bool interrupt)
         => MainClass.ScreenReader.Say(text, interrupt);

--- a/stardew-access/API.cs
+++ b/stardew-access/API.cs
@@ -31,6 +31,22 @@ public class API : IStardewAccessApi
     }
 #pragma warning disable CA1822 // Mark members as static
 
+    #region Keybinds
+    public KeybindList LeftClickMainKey => MainClass.Config.LeftClickMainKey;
+    public KeybindList RightClickMainKey => MainClass.Config.RightClickMainKey;
+    public KeybindList LeftClickAlternateKey => MainClass.Config.LeftClickAlternateKey;
+    public KeybindList RightClickAlternateKey => MainClass.Config.RightClickAlternateKey;
+    public KeybindList ChatMenuNextKey => MainClass.Config.ChatMenuNextKey;
+    public KeybindList ChatMenuPreviousKey => MainClass.Config.ChatMenuPreviousKey;
+    public KeybindList ReadTileKey => MainClass.Config.ReadTileKey;
+    public KeybindList ReadStandingTileKey => MainClass.Config.ReadStandingTileKey;
+    public KeybindList ReadFlooringKey => MainClass.Config.ReadFlooringKey;
+    public KeybindList TileCursorUpKey => MainClass.Config.TileCursorUpKey;
+    public KeybindList TileCursorRightKey => MainClass.Config.TileCursorRightKey;
+    public KeybindList TileCursorDownKey => MainClass.Config.TileCursorDownKey;
+    public KeybindList TileCursorLeftKey => MainClass.Config.TileCursorLeftKey;
+    #endregion
+
     #region Screen reader related
 
     public string PrevMenuQueryText

--- a/stardew-access/API.cs
+++ b/stardew-access/API.cs
@@ -100,6 +100,26 @@ public class API : IStardewAccessApi
     
     #endregion
 
+    #region Commands
+
+    public void SimulateLeftClick()
+    {
+        if (Game1.activeClickableMenu != null)
+            MouseUtils.SimulateMouseClicks((x, y) => Game1.activeClickableMenu.receiveLeftClick(x, y), null);
+        else if (Game1.currentMinigame != null)
+            MouseUtils.SimulateMouseClicks((x, y) => Game1.currentMinigame.receiveLeftClick(x, y), null);
+    }
+
+    public void SimulateRightClick()
+    {
+        if (Game1.activeClickableMenu != null)
+            MouseUtils.SimulateMouseClicks(null, (x, y) => Game1.activeClickableMenu.receiveRightClick(x, y));
+        else if (Game1.currentMinigame != null)
+            MouseUtils.SimulateMouseClicks(null, (x, y) => Game1.currentMinigame.receiveRightClick(x, y));
+    }
+
+    #endregion
+
     #region Tiles related
 
     public Dictionary<Vector2, (string name, string category)> SearchNearbyTiles(Vector2 center, int limit)

--- a/stardew-access/PublicApi/IStardewAccessApi.cs
+++ b/stardew-access/PublicApi/IStardewAccessApi.cs
@@ -36,6 +36,11 @@ public interface IStardewAccessApi
     KeybindList TileCursorDownKey { get; }
     /// <summary>Key to move the cursor one tile left.</summary>
     KeybindList TileCursorLeftKey { get; }
+    /// <summary>
+    /// (Default to `C`) Mainly used to speak some visual information in a menu like some label(s) which isn't
+    /// reachable by gamepad navigation.
+    /// </summary>
+    KeybindList PrimaryInfoKey { get; }
     #endregion
 
     #region Screen reader related
@@ -75,11 +80,6 @@ public interface IStardewAccessApi
     /// </summary>
     public string MenuSuffixNoQueryText { get; set; }
 
-    /// <summary>
-    /// (Default to `C`) Mainly used to speak some visual information in a menu like some label(s) which isn't
-    /// reachable by gamepad naviagtion.
-    /// </summary>
-    public KeybindList PrimaryInfoKey { get; }
 
     /// <summary>Speaks the text via the loaded screen reader (if any).</summary>
     /// <param name="text">The text to be narrated.</param>

--- a/stardew-access/PublicApi/IStardewAccessApi.cs
+++ b/stardew-access/PublicApi/IStardewAccessApi.cs
@@ -9,6 +9,35 @@ namespace stardew_access;
 // TODO: Update doc comments
 public interface IStardewAccessApi
 {
+    #region Keybinds
+    /// <summary>Primary key to simulate mouse left click.</summary>
+    KeybindList LeftClickMainKey { get; }
+    /// <summary>Primary key to simulate mouse right click.</summary>
+    KeybindList RightClickMainKey { get; }
+    /// <summary>Secondary key to simulate mouse left click.</summary>
+    KeybindList LeftClickAlternateKey { get; }
+    /// <summary>Secondary key to simulate mouse right click.</summary>
+    KeybindList RightClickAlternateKey { get; }
+    /// <summary>Key to read previous chat message.</summary>
+    KeybindList ChatMenuNextKey { get; }
+    /// <summary>Key to read next chat message.</summary>
+    KeybindList ChatMenuPreviousKey { get; }
+    /// <summary>Key to manually trigger read tile for the tile player is looking at.</summary>
+    KeybindList ReadTileKey { get; }
+    /// <summary>Key to manually trigger read tile for the tile player is standing on.</summary>
+    KeybindList ReadStandingTileKey { get; }
+    /// <summary>Key to toggle reading floorings.</summary>
+    KeybindList ReadFlooringKey { get; }
+    /// <summary>Key to move the cursor one tile up.</summary>
+    KeybindList TileCursorUpKey { get; }
+    /// <summary>Key to move the cursor one tile right.</summary>
+    KeybindList TileCursorRightKey { get; }
+    /// <summary>Key to move the cursor one tile down.</summary>
+    KeybindList TileCursorDownKey { get; }
+    /// <summary>Key to move the cursor one tile left.</summary>
+    KeybindList TileCursorLeftKey { get; }
+    #endregion
+
     #region Screen reader related
 
     /// <summary>

--- a/stardew-access/PublicApi/IStardewAccessApi.cs
+++ b/stardew-access/PublicApi/IStardewAccessApi.cs
@@ -103,6 +103,34 @@ public interface IStardewAccessApi
     
     #endregion
 
+    #region Commands
+
+    /// <summary>
+    /// Simulates a left mouse click at the current cursor position.
+    /// <para>
+    /// This method will trigger a left click on the currently active menu or minigame, if present.
+    /// It abstracts away internal details, so callers do not need to know the current game context.
+    /// </para>
+    /// <remarks>
+    /// If no menu or minigame is active, this method does nothing.
+    /// </remarks>
+    /// </summary>
+    public void SimulateLeftClick();
+
+    /// <summary>
+    /// Simulates a right mouse click at the current cursor position.
+    /// <para>
+    /// This method will trigger a right click on the currently active menu or minigame, if present.
+    /// It abstracts away internal details, so callers do not need to know the current game context.
+    /// </para>
+    /// <remarks>
+    /// If no menu or minigame is active, this method does nothing.
+    /// </remarks>
+    /// </summary>
+    public void SimulateRightClick();
+
+    #endregion
+
     #region Tiles related
 
     /// <summary>


### PR DESCRIPTION
fixes #498
Currently there is no way for other mods to make use of any commands added by SD Access.

This PR will expose internal functionality such as mouse click simulation so that other mod authors may use them in order to create more accessible mods.

## Changelog

### Misc

- Exposed keybindings some keybindings to the api, including the mouse sim keybinds,  primary info keybind and some others - by @paulGeoghegan  

