### PR TITLE
fix: Improve HUD message duplicate detection logic

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- HUD messages are no longer read out multiple times for the same event.
 
 ### Tile Tracker Changes
 

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -15,7 +15,7 @@ internal class GameStateNarrator : FeatureBase
     private static GameLocation? currentLocation;
     private static GameLocation? previousLocation;
 
-    private static string hudMessageQueryKey = "";
+    private static string lastNormalizedHudMessage = "";
     private static DateTime lastHudMessageTime = DateTime.MinValue;
     private static bool isNarratingHudMessage = false;
 
@@ -126,14 +126,14 @@ internal class GameStateNarrator : FeatureBase
             int lastIndex = Game1.hudMessages.Count - 1;
             HUDMessage lastMessage = Game1.hudMessages[lastIndex];
             string toSpeak = lastMessage.message;
-            var searchQuery = (Regex.Replace(toSpeak, @"[\d+]", string.Empty)).Trim();
-            var now = DateTime.Now;            
-            bool isDuplicate = hudMessageQueryKey == searchQuery;
-            bool withinTimeout = (now - lastHudMessageTime) < TimeSpan.FromMilliseconds(MainClass.Config.HudDuplicateMessageTimeout);
+            string normalized = Regex.Replace(toSpeak, "[0-9]+", "").Trim();
+            var now = DateTime.Now;
+            bool isSimilar = normalized == lastNormalizedHudMessage;
+            bool timeoutExpired = (now - lastHudMessageTime) >= TimeSpan.FromMilliseconds(MainClass.Config.HudDuplicateMessageTimeout);
 
-            if (!isDuplicate || !withinTimeout)
+            if (!isSimilar || timeoutExpired)
             {
-                hudMessageQueryKey = searchQuery;
+                lastNormalizedHudMessage = normalized;
                 lastHudMessageTime = now;
                 MainClass.ScreenReader.Say(toSpeak, true);
                 HudMessagesBuffer.Add(toSpeak);

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -16,6 +16,7 @@ internal class GameStateNarrator : FeatureBase
     private static GameLocation? previousLocation;
 
     private static string lastNormalizedHudMessage = "";
+    private static HUDMessage? lastSpokenHudMessage = null;
     private static DateTime lastHudMessageTime = DateTime.MinValue;
     private static bool isNarratingHudMessage = false;
 
@@ -129,11 +130,13 @@ internal class GameStateNarrator : FeatureBase
             string normalized = Regex.Replace(toSpeak, "[0-9]+", "").Trim();
             var now = DateTime.Now;
             bool isSimilar = normalized == lastNormalizedHudMessage;
+            bool isNewObject = lastMessage != lastSpokenHudMessage;
             bool timeoutExpired = (now - lastHudMessageTime) >= TimeSpan.FromMilliseconds(MainClass.Config.HudDuplicateMessageTimeout);
 
-            if (!isSimilar || timeoutExpired)
+            if ((timeoutExpired  || !isSimilar) && isNewObject)
             {
                 lastNormalizedHudMessage = normalized;
+                lastSpokenHudMessage = lastMessage;
                 lastHudMessageTime = now;
                 MainClass.ScreenReader.Say(toSpeak, true);
                 HudMessagesBuffer.Add(toSpeak);


### PR DESCRIPTION
fixes #499
Refactored HUD message normalization and duplicate detection by renaming variables and adjusting logic to better handle message similarity and timeout checks. This should reduce unnecessary repeated narration of similar HUD messages.

[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog



### Bug Fixes

- HUD messages are no longer read out multiple times for the same event.

