### PR TITLE
TileDataEntryMenu and invalid farm building data bug fixes

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- Fixed a bug in the TileDataEntryMenu that made the menu become unresponsive.
+- Fixed the object tracker crashing if a farm building has invalid data.
 
 ### Tile Tracker Changes
 

--- a/stardew-access/Features/TileViewer/TileDataEntryMenu.cs
+++ b/stardew-access/Features/TileViewer/TileDataEntryMenu.cs
@@ -438,7 +438,7 @@ public class TileDataEntryMenu : IClickableMenu
             return;
         }
 
-        OptionsElementUtils.NarrateHoveredElementFromList(_options);
+        OptionsElementUtils.NarrateHoveredElementFromList(_options, allowFallback: true);
 
         base.update(time);
     }

--- a/stardew-access/Utils/DynamicTiles.cs
+++ b/stardew-access/Utils/DynamicTiles.cs
@@ -426,7 +426,8 @@ public class DynamicTiles
         // Translated name, E.G> "Mill" becomes "Molino" for Spanish.
         // not all buildings have translated names, E.G. "Petbowl" and "Farmhouse" remain untranslated.
         // TODO add translation keys for untranslated building names.
-        string name = TokenParser.ParseText(building.GetData().Name);
+        var buildingData = building.GetData();
+        string name = TokenParser.ParseText(buildingData?.Name ?? building.buildingType.Value ?? "Unknown Building");
         int buildingTileX = building.tileX.Value;
         int buildingTileY = building.tileY.Value;
         // Calculate differences in x and y coordinates


### PR DESCRIPTION
[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog


### Bug Fixes
- Fixed a bug in the TileDataEntryMenu that made the menu become unresponsive.
- Fixed the object tracker crashing if a farm building has invalid data.

