### PR TITLE
patch advanced crafting options

### DIFF
--- a/docs/changelogs/latest.md
+++ b/docs/changelogs/latest.md
@@ -5,6 +5,8 @@
 
 ### Feature Updates
 
+- patched advanced crafting options to read out if and how often a recipe has been crafted or cooked.
+- its now also announced how many times the item can be crafted
 
 ### Bug Fixes
 
@@ -22,6 +24,7 @@
 
 ### Translation Changes
 
+- added a new translation-key in case a recipe has never been crafted or cooked
 
 ### Development Chores
 

--- a/stardew-access/Patches/GameMenuPatches/CraftingPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/CraftingPagePatch.cs
@@ -134,8 +134,10 @@ internal class CraftingPagePatch : IPatch
 
         Item producesItem = ___hoverRecipe.createItem();
         string translationKey = "menu-crafting_page-recipe_info";
+        IList<Item>? containerContents = GetContainerContents(__instance._materialContainers);
         int craftCountState = 0;
         string craftCountText = "";
+        int craftableCount = 0;
         if (Game1.options.showAdvancedCraftingInformation)
         {
             string? countText = ___hoverRecipe.getCraftCountText();
@@ -148,15 +150,17 @@ internal class CraftingPagePatch : IPatch
             {
                 craftCountState = ___hoverRecipe.isCookingRecipe ? 2 : 1;
             }
+            craftableCount = ___hoverRecipe.getCraftableCount(containerContents);
         }
         object translationTokens = new
             {
                 produce_count = ___hoverRecipe.numberProducedPerCraft,
                 name = ___hoverRecipe.DisplayName,
-                is_craftable = ___hoverRecipe.doesFarmerHaveIngredientsInInventory(GetContainerContents(__instance._materialContainers)) ? 1 : 0,
+                is_craftable = ___hoverRecipe.doesFarmerHaveIngredientsInInventory(containerContents) ? 1 : 0,
                 ingredients = InventoryUtils.GetIngredientsFromRecipe(___hoverRecipe),
                 craft_count = craftCountState,
                 craft_count_text = craftCountText,
+                craftable_count = craftableCount,
                 ___hoverRecipe.description,
                 buffs = $"{InventoryUtils.GetHealthNStaminaFromItem(producesItem)}, {InventoryUtils.GetBuffsFromItem(producesItem)}"
             };

--- a/stardew-access/Patches/GameMenuPatches/CraftingPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/CraftingPagePatch.cs
@@ -134,12 +134,29 @@ internal class CraftingPagePatch : IPatch
 
         Item producesItem = ___hoverRecipe.createItem();
         string translationKey = "menu-crafting_page-recipe_info";
+        int craftCountState = 0;
+        string craftCountText = "";
+        if (Game1.options.showAdvancedCraftingInformation)
+        {
+            string? countText = ___hoverRecipe.getCraftCountText();
+            if (countText != null)
+            {
+                craftCountState = 3;
+                craftCountText = countText;
+            }
+            else
+            {
+                craftCountState = ___hoverRecipe.isCookingRecipe ? 2 : 1;
+            }
+        }
         object translationTokens = new
             {
                 produce_count = ___hoverRecipe.numberProducedPerCraft,
                 name = ___hoverRecipe.DisplayName,
                 is_craftable = ___hoverRecipe.doesFarmerHaveIngredientsInInventory(GetContainerContents(__instance._materialContainers)) ? 1 : 0,
                 ingredients = InventoryUtils.GetIngredientsFromRecipe(___hoverRecipe),
+                craft_count = craftCountState,
+                craft_count_text = craftCountText,
                 ___hoverRecipe.description,
                 buffs = $"{InventoryUtils.GetHealthNStaminaFromItem(producesItem)}, {InventoryUtils.GetBuffsFromItem(producesItem)}"
             };

--- a/stardew-access/i18n/menu.en.ftl
+++ b/stardew-access/i18n/menu.en.ftl
@@ -227,9 +227,16 @@ menu-collections_page-unshipped = Unshipped
 
 ### Crafting Page
 
-menu-crafting_page-recipe_info = {$produce_count} {$name}, {$is_craftable ->
-    [0] not craftable
-    *[1] craftable
+menu-crafting_page-recipe_info = {$produce_count} {$name}, {$craftable_count ->
+    [0] {$is_craftable ->
+        [0] not craftable
+        *[1] craftable
+      }
+    [1] {$is_craftable ->
+        [0] not craftable
+        *[1] craftable
+      }
+    *[other] craftable {$craftable_count} times
   }, Ingredients: {$ingredients}{$craft_count ->
     [0] {EMPTYSTRING()}
     [1] , Never crafted

--- a/stardew-access/i18n/menu.en.ftl
+++ b/stardew-access/i18n/menu.en.ftl
@@ -230,7 +230,12 @@ menu-collections_page-unshipped = Unshipped
 menu-crafting_page-recipe_info = {$produce_count} {$name}, {$is_craftable ->
     [0] not craftable
     *[1] craftable
-  }, Ingredients: {$ingredients}, Description: {$description}, {$buffs}
+  }, Ingredients: {$ingredients}{$craft_count ->
+    [0] {EMPTYSTRING()}
+    [1] , Never crafted
+    [2] , Never cooked
+    *[3] , {$craft_count_text}
+  }, Description: {$description}, {$buffs}
 menu-crafting_page-unknown_recipe = Unknown recipe
 menu-crafting_page-previous_recipe_list_button = Previous recipe list button
 menu-crafting_page-next_recipe_list_button = Next recipe list button


### PR DESCRIPTION
fixes #514 
[//]: # (A few things to note:)
[//]: # (1. Write each changelog as an unordered list in their appropriate sub-heading)
[//]: # (2. The changelogs will be automatically added to `docs/changelogs/latest.md` by the merge workflow)
[//]: # (3. You can write an overview or anything that you don't want to be included as changelog before the 'Changelog' heading)
[//]: # (4. Do not change the heading names and/or the heading levels)
[//]: # (5. Remove the unwanted changelog sections)


## Changelog



### Feature Updates
- patched advanced crafting options to read out if and how often a recipe has been crafted or cooked.
- its now also announced how many times the item can be crafted


### Translation Changes
- added a new translation-key in case a recipe has never been crafted or cooked



